### PR TITLE
[Feat] 버튼 컴포넌트 Size 수정

### DIFF
--- a/src/common/component/Button/Button.style.ts
+++ b/src/common/component/Button/Button.style.ts
@@ -58,10 +58,10 @@ export const variantStyle = (variant: Required<ButtonProps>['variant']) => {
       },
     }),
     outline: css({
-      border: `1px solid ${theme.colors.gray_300}`,
-
       color: theme.colors.gray_800,
       backgroundColor: theme.colors.white,
+
+      boxShadow: theme.shadow.inset,
 
       '&:hover': {
         backgroundColor: theme.colors.gray_100,

--- a/src/common/component/Button/Button.style.ts
+++ b/src/common/component/Button/Button.style.ts
@@ -10,10 +10,6 @@ export const buttonStyle = css({
   alignItems: 'center',
   gap: '0.4rem',
 
-  width: '100%',
-
-  padding: '1.6rem 1.4rem',
-
   border: 'none',
   borderRadius: '8px',
 

--- a/src/common/component/Button/Button.style.ts
+++ b/src/common/component/Button/Button.style.ts
@@ -88,13 +88,36 @@ export const variantStyle = (variant: Required<ButtonProps>['variant']) => {
 
 export const sizeStyle = (size: Required<ButtonProps>['size']) => {
   const style = {
-    large: css({
-      ...theme.text.body04,
-    }),
-    medium: css({
+    /** Button_46 */
+    xLarge: css({
+      padding: '1.6rem 1.4rem',
+
       ...theme.text.body06,
     }),
+    /** Button_40 */
+    large: css({
+      padding: '1.4rem',
+
+      ...theme.text.body08,
+    }),
+    /** Button_36 */
+    medium: css({
+      padding: '1.2rem 1.4rem',
+
+      ...theme.text.body08,
+    }),
+    /** Button_32 */
     small: css({
+      padding: '1rem 1.4rem',
+
+      ...theme.text.body08,
+    }),
+    /** Button_24 */
+    xSmall: css({
+      padding: '0.6rem 1rem',
+
+      borderRadius: '1.2rem',
+
       ...theme.text.body08,
     }),
   };

--- a/src/common/component/Button/Button.tsx
+++ b/src/common/component/Button/Button.tsx
@@ -9,7 +9,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: Extract<Size, 'xLarge' | 'large' | 'medium' | 'small' | 'xSmall'>;
 }
 
-const Button = ({ variant = 'primary', children, size = 'small', ...props }: ButtonProps) => {
+const Button = ({ variant = 'primary', children, size = 'medium', ...props }: ButtonProps) => {
   return (
     <button type="button" css={[buttonStyle, variantStyle(variant), sizeStyle(size)]} {...props}>
       {children}

--- a/src/common/component/Button/Button.tsx
+++ b/src/common/component/Button/Button.tsx
@@ -6,7 +6,7 @@ import { buttonStyle, sizeStyle, variantStyle } from './Button.style';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'outline' | 'underline';
-  size?: Extract<Size, 'large' | 'medium' | 'small'>;
+  size?: Extract<Size, 'xLarge' | 'large' | 'medium' | 'small' | 'xSmall'>;
 }
 
 const Button = ({ variant = 'primary', children, size = 'small', ...props }: ButtonProps) => {

--- a/src/common/component/CommandButton/CommandButton.tsx
+++ b/src/common/component/CommandButton/CommandButton.tsx
@@ -12,6 +12,7 @@ import {
 
 interface CommandButtonProps extends ButtonProps {
   variant?: Extract<ButtonProps['variant'], 'primary' | 'tertiary' | 'outline'>;
+  size?: Extract<ButtonProps['size'], 'large' | 'small'>;
   commandKey: string;
   isCommand?: boolean;
   isFrontIcon?: boolean;
@@ -20,7 +21,7 @@ interface CommandButtonProps extends ButtonProps {
 
 const CommandButton = ({
   variant = 'primary',
-  size = 'small',
+  size = 'large',
   commandKey,
   isCommand = true,
   isFrontIcon = false,

--- a/src/story/common/Button.stories.tsx
+++ b/src/story/common/Button.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     },
     size: {
       control: { type: 'radio' },
-      options: ['xlarge', 'large', 'medium', 'small', 'xSmall'],
+      options: ['xLarge', 'large', 'medium', 'small', 'xSmall'],
     },
     children: {
       control: { type: 'text' },

--- a/src/story/common/Button.stories.tsx
+++ b/src/story/common/Button.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     },
     size: {
       control: { type: 'radio' },
-      options: ['large', 'medium', 'small'],
+      options: ['xlarge', 'large', 'medium', 'small', 'xSmall'],
     },
     children: {
       control: { type: 'text' },

--- a/src/story/common/CommandButton.stories.tsx
+++ b/src/story/common/CommandButton.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     },
     size: {
       control: { type: 'radio' },
-      options: ['large', 'medium', 'small'],
+      options: ['large', 'small'],
     },
     commandKey: {
       control: {
@@ -38,7 +38,7 @@ const meta = {
   },
   args: {
     variant: 'primary',
-    size: 'small',
+    size: 'large',
     children: 'Button',
     disabled: false,
   },


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #272

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 


---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

피그마 - `Components` 페이지의 버튼 스타일에 맞게 `padding`과 `font` 지정해줬습니다.

`underline` variant의 경우 피그마 상에선 글자 크기에 맞게 버튼 영역이 설정되어 있어서 이걸 따로 size로 만들어야 하나 고민했는데, storybook에서 버튼 영역 잡아보니까 오히려 조금은 padding으로 버튼 영역을 설정해둔 게 더 자연스러운 것 같아서 따로 만들어주지 않았습니다 !

---

## 📌스크린샷 (선택)

스토리북 확인해주셔요 ~