### PR TITLE
[Refactor] Common 인풋과 Count Input 분리

### DIFF
--- a/src/common/component/CountedInput/CountedInput.style.ts
+++ b/src/common/component/CountedInput/CountedInput.style.ts
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+
+import { theme } from '@/common/style/theme/theme';
+
+export const containerStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.2rem',
+
+  width: '100%',
+
+  '& > label': {
+    margin: '0 0 1rem',
+  },
+});
+
+export const inputStyle = css({
+  width: '100%',
+
+  paddingRight: '4rem',
+
+  border: 'none',
+  backgroundColor: 'transparent',
+
+  fontWeight: 400,
+  ...theme.text.body06,
+
+  outline: 'none',
+
+  '::placeholder': {
+    color: theme.colors.gray_500,
+    ...theme.text.body06,
+  },
+});
+
+export const inputWrapperStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1rem',
+
+  position: 'relative',
+
+  height: '4rem',
+
+  padding: '1.3rem 1.2rem',
+
+  backgroundColor: 'transparent',
+  boxShadow: theme.shadow.inset,
+  borderRadius: '8px',
+
+  '&:focus-within': {
+    boxShadow: theme.shadow.inset_focus,
+  },
+});
+
+export const countTextStyle = css({
+  position: 'absolute',
+
+  ...theme.text.body06,
+  color: theme.colors.gray_500,
+
+  right: '1.2rem',
+});

--- a/src/common/component/CountedInput/CountedInput.tsx
+++ b/src/common/component/CountedInput/CountedInput.tsx
@@ -1,0 +1,50 @@
+import { ChangeEvent, ForwardedRef, InputHTMLAttributes, forwardRef, useState } from 'react';
+
+import {
+  containerStyle,
+  countTextStyle,
+  inputStyle,
+  inputWrapperStyle,
+} from '@/common/component/CountedInput/CountedInput.style';
+import Label from '@/common/component/Label/Label';
+import SupportingText from '@/common/component/SupportingText/SupportingText';
+
+export interface CountedInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  maxLength: number;
+  isError?: boolean;
+  isSuccess?: boolean;
+  supportingText?: string;
+}
+
+/** 비제어 컴포넌트로 활용, 폼 제출 시 ref.current 값으로 전달 */
+const CountedInput = (
+  { label, maxLength, isError = false, isSuccess = false, supportingText, ...props }: CountedInputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const [count, setCount] = useState(0);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (count === maxLength) {
+      e.target.value = e.target.value.substring(0, maxLength);
+    }
+    setCount(e.target.value.length);
+  };
+
+  return (
+    <div css={containerStyle}>
+      {label && <Label id={label}>{label}</Label>}
+      <div css={inputWrapperStyle}>
+        <input ref={ref} css={inputStyle} onChange={onChange} {...props} />
+        <span css={countTextStyle}>{`${count}/${maxLength}`}</span>
+      </div>
+      {supportingText && (
+        <SupportingText isError={isError} isNotice={isSuccess}>
+          {supportingText}
+        </SupportingText>
+      )}
+    </div>
+  );
+};
+
+export default forwardRef(CountedInput);

--- a/src/common/component/Input/Input.style.ts
+++ b/src/common/component/Input/Input.style.ts
@@ -5,7 +5,6 @@ import { theme } from '@/common/style/theme/theme';
 export const containerStyle = css({
   display: 'flex',
   flexDirection: 'column',
-
   gap: '0.2rem',
 
   width: '100%',
@@ -33,26 +32,21 @@ export const inputStyle = css({
 
 export const contentStyle = (isFilled: boolean) =>
   css({
-    position: 'relative',
     display: 'flex',
     alignItems: 'center',
     gap: '1rem',
 
+    position: 'relative',
+
+    height: '4rem',
+
     padding: '1.3rem 1.2rem',
 
     backgroundColor: isFilled ? theme.colors.gray_100 : 'none',
-    boxShadow: `inset 0px 0px 0px 1px ${theme.colors.gray_300}`,
+    boxShadow: theme.shadow.inset,
     borderRadius: '8px',
 
     '&:focus-within': {
-      boxShadow: `inset 0px 0px 0px 1px ${theme.colors.key_500}`,
+      boxShadow: theme.shadow.inset_focus,
     },
   });
-
-export const countStyle = css({
-  position: 'absolute',
-  right: '1.2rem',
-
-  ...theme.text.body06,
-  color: theme.colors.gray_500,
-});

--- a/src/common/component/Input/Input.tsx
+++ b/src/common/component/Input/Input.tsx
@@ -1,51 +1,28 @@
-import { ChangeEvent, ForwardedRef, InputHTMLAttributes, ReactNode, forwardRef, useState } from 'react';
+import { ForwardedRef, InputHTMLAttributes, ReactNode, forwardRef } from 'react';
 
-import { containerStyle, contentStyle, countStyle, inputStyle } from '@/common/component/Input/Input.style';
+import { containerStyle, contentStyle, inputStyle } from '@/common/component/Input/Input.style';
 import Label from '@/common/component/Label/Label';
 import SupportingText from '@/common/component/SupportingText/SupportingText';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  filled?: boolean;
   LeftIcon?: ReactNode;
-  hasCount?: boolean; //글자수 세기
+  isFilled?: boolean;
   isError?: boolean;
   isSuccess?: boolean;
   supportingText?: string;
 }
 
 const Input = (
-  {
-    label,
-    filled = false,
-    LeftIcon,
-    hasCount,
-    isError = false,
-    isSuccess = false,
-    supportingText,
-    ...props
-  }: InputProps,
+  { label, isFilled = false, LeftIcon, isError = false, isSuccess = false, supportingText, ...props }: InputProps,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
-  const [count, setCount] = useState(0);
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (count === props.maxLength) {
-      e.target.value = e.target.value.substring(0, props.maxLength);
-    }
-    setCount(e.target.value.length);
-  };
   return (
     <div css={containerStyle}>
       {label && <Label id={label}>{label}</Label>}
-      <div css={contentStyle(filled)}>
+      <div css={contentStyle(isFilled)}>
         {LeftIcon}
-        <input ref={ref} onChange={onChange} css={inputStyle} {...props} />
-        {hasCount && (
-          <span css={countStyle}>
-            {count}/{props.maxLength}
-          </span>
-        )}
+        <input ref={ref} css={inputStyle} {...props} />
       </div>
       {supportingText && (
         <SupportingText isError={isError} isNotice={isSuccess}>

--- a/src/story/common/CountedInput.stories.tsx
+++ b/src/story/common/CountedInput.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useRef } from 'react';
+
+import CountedInput from '@/common/component/CountedInput/CountedInput';
+
+const meta = {
+  title: 'Common/CountedInput',
+  component: CountedInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CountedInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    maxLength: 20,
+    label: '카운트 인풋',
+  },
+  render: (args) => {
+    const ref = useRef<HTMLInputElement | null>(null);
+
+    const _onSubmit = () => {
+      if (!ref.current) return;
+
+      ref.current.value;
+    };
+
+    return (
+      <form onSubmit={_onSubmit}>
+        <CountedInput {...args} ref={ref} />
+      </form>
+    );
+  },
+};

--- a/src/story/common/Input.stories.tsx
+++ b/src/story/common/Input.stories.tsx
@@ -35,13 +35,13 @@ export const Default: Story = {
 export const Search: Story = {
   args: {
     LeftIcon: <SearchIc width={16} height={16} />,
-    filled: false,
+    isFilled: false,
   },
   argTypes: {
     LeftIcon: {
       control: false,
     },
-    filled: {
+    isFilled: {
       control: { type: 'boolean' },
     },
   },
@@ -49,29 +49,11 @@ export const Search: Story = {
 
 export const Filled: Story = {
   args: {
-    filled: true,
+    isFilled: true,
   },
   argTypes: {
-    filled: {
+    isFilled: {
       control: false,
-    },
-  },
-};
-
-export const Count: Story = {
-  args: {
-    hasCount: true,
-    maxLength: 10,
-  },
-  argTypes: {
-    hasCount: { control: false },
-    maxLength: {
-      control: { type: 'number' },
-    },
-    filled: {
-      control: {
-        type: 'boolean',
-      },
     },
   },
 };


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #288 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point

기존에 보운님께서 `Input` 컴포넌트 디벨롭해주실 때, 한 컴포넌트 안에서 `onChange`를 생성하여 input의 `change` 핸들러로 연결해주었습니다. 저는 그래서 기존 `props.onChange`와 `count`라는 상태를 하나의 함수 안에서 업데이트해주고, 해당 함수를 `input`의 `change` 이벤트로 연결해주면 되겠다는 생각을 가지고 시도해봤는데, 여럿 이슈가 있었습니다.

### `state`의 비동기적 업데이트 이슈

먼저 처음 시도한 방법은 다음과 같습니다.

```ts
const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
    if (props.maxLength && e.target.value.length > props?.maxLength) {
      e.target.value = e.target.value.slice(0, props.maxLength);
    }
    setCount(e.target.value.length);

    props.onChange?.(e);
  };
```

먼저 `input`에 `value`와 `onChange`를 연결한 상태에서 `maxLength`를 부여했을 때, 기본적으로 한글은 한글자가 입력되게 됩니다. 영문자는 `1byte` 한글은 `2byte`여서 그렇다고 하네요 ! 그래서 만약 `maxLength`가 50이라고 했을 때 49글자에서 한글을 입력하게 되면 곧바로 51로 이동하게 됩니다. 51인 상태에서 입력이 안되게 되요 ! 
이를 해결하기 위해서 보운님이 잘 작성해주신대로 `e.target.value.length`와 `maxLength`를 비교하여 `slice` 해주는 방식을 그대로 이용해주었습니다.

여기서는 또 다시 `state`의 비동기적 업데이트 이슈가 발생하게 되었습니다. `count`와 `onChange` 둘다 상태를 업데이트하는 함수입니다. 

```
1. onChange로 input의 value 비동기적 업데이트
2. setCount의 e.target.value는 아직 0
3. 다시 한글자 입력하여 onChange 실행, value 비동기적 업데이트
4. e.target.value는 여전히 0
```

즉 위에서 전달받은 `value`라는 상태의 업데이트와, `count`라는 상태가 동기적으로 처리될 수 없기 때문에 발생합니다.

### CountedInput

그래서 분리하였어요 ! 이 때 기존에 보운님이 구현하신 `onChange`를 연결해주되, 비제어 컴포넌트를 활용하였습니다. 즉 한글자 한글자를 `state`로 제어하지 않고 `ref`를 통해 폼이 제출될 당시에 `ref.current.value`로 접근하여 값을 활용할 수 있습니다.

---

## 📌스크린샷 (선택)

스토리북으로 확인해주세용 