### PR TITLE
[Feat] 지연 렌더링을 통한 검색 Input 필터링 기능 구현

### DIFF
--- a/.github/workflows/automatic-aws-deployment.yml
+++ b/.github/workflows/automatic-aws-deployment.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   cicd:

--- a/src/common/hook/useDeferedSearchFilter.ts
+++ b/src/common/hook/useDeferedSearchFilter.ts
@@ -1,0 +1,30 @@
+import { useDeferredValue } from 'react';
+
+type Data<T> = {
+  [K in keyof T]: T[K];
+};
+
+/**
+ * - useDeferedValue 훅을 사용한 UI 지연 렌더링 + 필터링
+ * 검색 기능 시 사용
+ */
+const useDeferedSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
+  const deferredValue = useDeferredValue(value);
+
+  const isStale = value !== deferredValue;
+
+  const filteredData = list.filter((item) =>
+    Object.values(item).some((value) => {
+      if (typeof value === 'object') {
+        /** deep comparing 대신 객체를 문자열로 만들어 검사 */
+        return JSON.stringify(value).includes(deferredValue);
+      } else {
+        return String(value).includes(deferredValue);
+      }
+    })
+  );
+
+  return { deferredValue, filteredData, isStale };
+};
+
+export default useDeferedSearchFilter;

--- a/src/common/hook/useDeferedSearchFilter.ts
+++ b/src/common/hook/useDeferedSearchFilter.ts
@@ -11,6 +11,7 @@ type Data<T> = {
 const useDeferedSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
   const deferredValue = useDeferredValue(value);
 
+  /** 상태 업데이트 시 이전 값과 지연된 값이 일치하지 않으면 isState(아직 렌더링 전임을 UI로 나타내기 위함) */
   const isStale = value !== deferredValue;
 
   const filteredData = list.filter((item) =>

--- a/src/common/hook/useDeferedSearchFilter.ts
+++ b/src/common/hook/useDeferedSearchFilter.ts
@@ -18,7 +18,7 @@ const useDeferredSearchFilter = <T extends object>(list: Data<T>[], value: strin
     Object.values(item).some((value) => {
       if (typeof value === 'object') {
         /** deep comparing 대신 객체를 문자열로 만들어 검사 */
-        return JSON.stringify(value).includes(deferredValue);
+        return JSON.stringify(Object.values(value!)).includes(deferredValue);
       } else {
         return String(value).includes(deferredValue);
       }

--- a/src/common/hook/useDeferedSearchFilter.ts
+++ b/src/common/hook/useDeferedSearchFilter.ts
@@ -11,7 +11,7 @@ type Data<T> = {
 const useDeferedSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
   const deferredValue = useDeferredValue(value);
 
-  /** 상태 업데이트 시 이전 값과 지연된 값이 일치하지 않으면 isState(아직 렌더링 전임을 UI로 나타내기 위함) */
+  /** 상태 업데이트 시 이전 값과 지연된 값이 일치하지 않으면 isStale (아직 최신 데이터가 로드 전임을 UI로 나타내기 위함) */
   const isStale = value !== deferredValue;
 
   const filteredData = list.filter((item) =>

--- a/src/common/hook/useDeferedSearchFilter.ts
+++ b/src/common/hook/useDeferedSearchFilter.ts
@@ -8,7 +8,7 @@ type Data<T> = {
  * - useDeferedValue 훅을 사용한 UI 지연 렌더링 + 필터링
  * 검색 기능 시 사용
  */
-const useDeferedSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
+const useDeferredSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
   const deferredValue = useDeferredValue(value);
 
   /** 상태 업데이트 시 이전 값과 지연된 값이 일치하지 않으면 isStale (아직 최신 데이터가 로드 전임을 UI로 나타내기 위함) */
@@ -28,4 +28,4 @@ const useDeferedSearchFilter = <T extends object>(list: Data<T>[], value: string
   return { deferredValue, filteredData, isStale };
 };
 
-export default useDeferedSearchFilter;
+export default useDeferredSearchFilter;

--- a/src/page/drive/index.tsx
+++ b/src/page/drive/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 
 import Grid from '@/common/asset/svg/ic_grid.svg?react';
 import List from '@/common/asset/svg/ic_list.svg?react';
@@ -64,26 +64,24 @@ const DrivePage = () => {
           </Flex>
         </Flex>
       }>
-      <Suspense fallback={<p>Loading ...</p>}>
-        {alignOption === 'list' ? (
-          <>
-            <FileListHeader onSelectAll={() => {}} />
-            <ul>
-              {filteredData.map((item) => (
-                <div css={{ opacity: isStale ? 0.4 : 1 }}>
-                  <FileListItem key={item.fileId} {...item} />
-                </div>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <ul css={contentStyle}>
+      {alignOption === 'list' ? (
+        <>
+          <FileListHeader onSelectAll={() => {}} />
+          <ul>
             {filteredData.map((item) => (
-              <FileGrid key={item.fileId} title={item.title} volume={item.volume} type={item.type} />
+              <div css={{ opacity: isStale ? 0.4 : 1 }}>
+                <FileListItem key={item.fileId} {...item} />
+              </div>
             ))}
           </ul>
-        )}
-      </Suspense>
+        </>
+      ) : (
+        <ul css={contentStyle}>
+          {filteredData.map((item) => (
+            <FileGrid key={item.fileId} title={item.title} volume={item.volume} type={item.type} />
+          ))}
+        </ul>
+      )}
     </ContentBox>
   );
 };


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #295 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 📌 내가 알게 된 부분

기존에 동시성 렌더링을 위해 react 18에 새롭게 도입된 `useDeferedValue`와 `useTransition`에 대해 개념적으로만 알고 있었는데, 실제로 사용해보는 계기가 되었고, 더욱 깊게 지연 렌더링이라는 개념에 대해 알 수 있었습니다 !

`useDeferedValue`는 말 그대로 특정 상태를 지연시키는 역할을 합니다. 그렇다면 "지연"시키는 것이 무엇이냐, 예시를 들어보겠습니다.

`input`요소가 있고 내가 여기에 검색을 한다고 생각해보겠습니다. `a`를 입력합니다. 그렇다면 `value`와 `deferedValue`는 초기에 `a`, `''`가 되게 됩니다. 그리고 UI는 `blocking`이 되고, 리액트는 먼저 지연된 상태(`''`)로 리렌더링을 한 후에 새로운 상태(`a`)에 대한 업데이트를 백그라운드에서 수행합니다. 그 후 최신 상태에 대한 업데이트가 백그라운드에서 모두 업데이트된다면, `value`와 `deferedvalue` 모두 `a`라는 값이 되게 됩니다. 여기서 "지연"되는 시간이란 디바운스나 쓰로틀링과 같이 고정된 시간이 아닌, 사용자별로 네트워크에 따라 유연하게 설정되는 시간입니다.

또 하나 중요한 점은, 이 동시성 렌더링을 위해 사용되는 훅들의 특징은 만약 백그라운드 업데이트가 되고 있을 시에 새로운 상태에 대한 업데이트 요청이 들어온다면, 진행 중이던 업데이트를 다시 지연 혹은 중단시키고 새로운 상태에 대해 업데이트를 실행한다는 점입니다. 즉, 지연된 상태로서 리렌더링을 실시하여 이전의 상태들을 보여주어 `UX`를 해치지 않으면서도, 백그라운드에서 최신의 상태에 대한 업데이트를 수행합니다. 여기서 우리가 흔히 아는 디바운싱과 쓰로틀링과의 차이점이 중요합니다 !

- debounce (딜레이 0.5초라 가정)
(인풋 키 입력 상황이라 가정): `a` 입력 -> 0.5초 대기 -> `b` 입력 (`ab`) -> 0.5초 대기 -> `c` 입력 (`abc`) -> 0.5초 대기 -> 대기 시간 끝남 -> `abc`라는 최종 결과만으로만 리렌더링을 수행

- deferredValue (딜레이는 네트워크 상황에 맞게 유연)
(동일한 상황): `a` 입력 -> 대기 -> 중간에 `b` 다시 입력 -> `a` 렌더링 지연/`b` 입력 처리 (지연된 `a`로 먼저 리렌더링을 수행, 백그라운드에서는 `ab`로 업데이트 시도) -> 대기 -> 중간에 다시 `c` 입력 -> `ab` 지연/ `c` 입력 처리 -> 대기 시간 종료 -> `ab`를 보여주다 `abc`가 업데이트되었으니 최신 상태 보여줌.

이와 같이 동시성 렌더링에 있어서 "지연"이란, 상태 업데이트를 아예 막는 것이 아니라 우선순위를 낮춰 이후에 업데이트하는 것을 의미합니다. 디바운싱은 대기 시간동안 상태 업데이트가 여럿 들어온다면 가장 마지막의 상태만 업데이트한다면, `deferredvalue`는 우선순위가 높은 것부터 차례로 지연된 상태들을 업데이트할 수 있습니다. 따라서 UX 면에서 사용자에게 부드러운 화면 전환이나 UI 렌더링을 자연스럽게 만들 수 있습니다.

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

`useDeferredSearchFilter` 라는 훅을 구현했습니다. 즉 검색을 통한 리스트 필터링을 좀 더 쉽게 구현할 수 있도록 하였습니다. `list`와 `value`를 파라미터로 받는데, `list`는 초기 리스트, `value`는 검색 필드의 입력값을 넣으면 됩니다. 구현체는 다음과 같아요

```ts
const useDeferredSearchFilter = <T extends object>(list: Data<T>[], value: string) => {
  const deferredValue = useDeferredValue(value);

  /** 상태 업데이트 시 이전 값과 지연된 값이 일치하지 않으면 isStale (아직 최신 데이터가 로드 전임을 UI로 나타내기 위함) */
  const isStale = value !== deferredValue;

  const filteredData = list.filter((item) =>
    Object.values(item).some((value) => {
      if (typeof value === 'object') {
        /** deep comparing 대신 객체를 문자열로 만들어 검사 */
        return JSON.stringify(Object.values(value!)).includes(deferredValue);
      } else {
        return String(value).includes(deferredValue);
      }
    })
  );

  return { deferredValue, filteredData, isStale };
};
```

여기서 `isStale`이라는 변수를 굉장히 유용하게 사용할 수 있습니다 ! 해당 변수의 의미는 `react-query`의 `staleTime`과 비슷하게 오래된 데이터라는 의미입니다. 리액트는 `useDeferredValue`의 인자로 넣은 상태가 업데이트되면, 재빠르게 이전의 상태로 리렌더링을 시작하고 그 후 새로운 값으로 해당 상태를 백그라운드에서 업데이트합니다. 따라서 사용자는 잠시 동안 이전의 데이터를 볼 수 있으며, 특정 시간 이후에 로드된 새로운 상태를 맞이하게 됩니다.

`list`를 `filter`하는데, 안에서 객체 요소에 대해 다시 한번 `Object.values(item).some()`을 진행합니다. 즉 `if`문 이하를 만족하는 프로퍼티가 하나라도 나온다면, 해당 객체는 `filteredData`에 들어가게 됩니다.

`filteredData`를 계산하는 과정에서 객체 배열 요소의 하나의 객체 요소에 대해 `key`값에 대한 `string` 타입 `value`만을 검사하려고 했으나, 중첩된 객체가 있을 수도 있다고 생각하여 `JSON.stringify`를 사용하였습니다. 즉 `value`로 이루어진 배열을 만든 후 `JSON.stringify`에 넣어 문자열로 변환된 배열에서 값 검사를 수행하였습니다.

---

## 📌스크린샷 (선택)

- 리스트
![image](https://github.com/user-attachments/assets/825fb20e-8d02-4973-8cc5-e663f3f4d3c7)

- 중첩 객체 `info` 안의 "최주용"을 "최"라는 value로 검사
<img width="1582" alt="스크린샷 2024-10-25 오후 11 54 28" src="https://github.com/user-attachments/assets/2646ed28-6a84-4a16-a12d-523b0b4fc1e6">

- 체감을 위해 디바운싱으로 `isStale` 효과를 나타낸 화면, 실제로는 유저의 네트워크 속도가 반영되므로 훨씬 빠름

![](https://github.com/user-attachments/assets/0a702a42-3f9b-4351-a2b6-4deabd53a6d9)


- 실제 화면
![](https://github.com/user-attachments/assets/685b8e8e-8f9b-4834-8c1e-9831b5d5e8a4)





