### PR TITLE
[Fix] 쌓임맥락 고려하여 Tooltip 재배치

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-query-devtools": "^5.49.2",
     "axios": "^1.7.2",
+    "framer-motion": "^11.11.11",
     "mime": "^4.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       axios:
         specifier: ^1.7.2
         version: 1.7.2
+      framer-motion:
+        specifier: ^11.11.11
+        version: 11.11.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       mime:
         specifier: ^4.0.4
         version: 4.0.4
@@ -2836,6 +2839,20 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  framer-motion@11.11.11:
+    resolution: {integrity: sha512-tuDH23ptJAKUHGydJQII9PhABNJBpB+z0P1bmgKK9QFIssHGlfPd6kxMq00LSKwE27WFsb2z0ovY0bpUyMvfRw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -7886,6 +7903,13 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
+
+  framer-motion@11.11.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      tslib: 2.6.3
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
 

--- a/src/common/component/Carousel/Carousel.style.ts
+++ b/src/common/component/Carousel/Carousel.style.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { CarouselProps } from '@/common/component/Carousel/Carousel';
-import { theme } from '@/common/style/theme/theme';
 
 export const itemStyle = (height: string) =>
   css({
@@ -67,8 +66,6 @@ export const arrowStyle = (position: 'left' | 'right') =>
 
     width: '3.2rem',
     height: '3.2rem',
-
-    zIndex: theme.zIndex.overlayBottom,
 
     border: 'none',
     borderRadius: '16px',

--- a/src/common/component/ToolTip/ToolTip.style.ts
+++ b/src/common/component/ToolTip/ToolTip.style.ts
@@ -16,8 +16,6 @@ export const messageStyle = (isVisible: boolean) =>
     padding: '1rem',
     borderRadius: '8px',
 
-    zIndex: theme.zIndex.overlayTop,
-
     backgroundColor: `${theme.colors.gray_900}`,
     font: `${theme.text.body08}`,
     color: `${theme.colors.white}`,

--- a/src/shared/component/ContentBox/ContentBox.style.ts
+++ b/src/shared/component/ContentBox/ContentBox.style.ts
@@ -53,8 +53,6 @@ export const headerStyle = css({
 
   height: '7.2rem',
 
-  zIndex: theme.zIndex.overlayBottom,
-
   padding: '1.6rem 0rem',
 
   borderBottom: `1px solid ${theme.colors.gray_200}`,

--- a/src/shared/component/RouteNav/RouteNav.style.ts
+++ b/src/shared/component/RouteNav/RouteNav.style.ts
@@ -45,7 +45,7 @@ export const itemStyle = (isActive: boolean) =>
 
     whiteSpace: 'nowrap',
 
-    zIndex: 2,
+    zIndex: 1,
   });
 
 export const indicatorStyle = css({
@@ -58,6 +58,4 @@ export const indicatorStyle = css({
   backgroundColor: theme.colors.white,
 
   borderRadius: '4px',
-
-  zIndex: 1,
 });

--- a/src/shared/component/SideNavBar/SideNavBar.style.ts
+++ b/src/shared/component/SideNavBar/SideNavBar.style.ts
@@ -8,6 +8,8 @@ export const containerStyle = css({
   height: '100vh',
 
   borderRight: `1px solid ${theme.colors.gray_300}`,
+
+  zIndex: theme.zIndex.overlayMiddle,
 });
 
 export const tikiLogoStyle = css({


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #313 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 


---

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
---

`쌓임 맥락`이라는 개념에 대해 막연하게 듣기만 했는데 이걸 이제야 개념을 이해한 것 같습니다.

현재 Tooltip은 SideNavBar 컴포넌트 내부에 위치하고 있으며, SideNavBar 구조는 아래와 같습니다:

```tsx
      <Login>
        <ModalContainer />

        <SideNavBar />

        <div css={layoutStyle}>
          <main css={outletStyle}>
            <Header />
            <Outlet />
          </main>
          <GlobalDrawer />
        </div>
      </Login>
```
Tooltip이 다른 컴포넌트에 의해 가려지는 문제의 원인은 부모 컴포넌트인 SideNavBar에 쌓임 맥락이 생성되어 있지 않기 때문입니다. 여기서 "쌓임 맥락이 생성된다"는 것은 z-index가 auto가 아닌 값으로 지정되어 있는 것을 의미합니다.

Tooltip 컴포넌트는 SideNavBar의 쌓임 맥락을 따르기 때문에, 단순히 z-index를 부여해도 부모의 쌓임 맥락에 가로막혀 contentBox에 의해 가려지는 문제가 발생한 것입니다.

따라서 SideNavBar의 스타일에 zIndex를 부여함으로써 해결할 수 있었어요.

[아티클](https://velog.io/@zad1264/z-index%EC%99%80-%EC%8C%93%EC%9E%84-%EB%A7%A5%EB%9D%BD-%EC%A0%95%EB%A6%AC-%EC%99%9C-z-index%EA%B0%80-%EC%9C%84%EB%A1%9C-%EC%95%88%EC%98%AC%EB%9D%BC%EA%B0%88%EA%B9%8C) 참고하시면 좋을 것 같습니다

## 📌스크린샷 (선택)


https://github.com/user-attachments/assets/2df59857-b9cb-4763-a11a-be61b05dd04b

