### PR TITLE
[Fix] 아카이빙 페이지 api path 수정

### DIFF
--- a/apps/client/src/page/archiving/index/ArchivingPage.tsx
+++ b/apps/client/src/page/archiving/index/ArchivingPage.tsx
@@ -5,10 +5,9 @@ import { useLocation } from 'react-router-dom';
 
 import { contentStyle, pageStyle, timelineStyle } from '@/page/archiving/index/ArchivingPage.style';
 import DateProvider from '@/page/archiving/index/DateProvider';
-import TimeLine from '@/page/archiving/index/component/TimeLine';
+import TimeLine, { TimeBlockData } from '@/page/archiving/index/component/TimeLine';
 import TimeLineHeader from '@/page/archiving/index/component/TimeLine/TimeLineHeader/TimeLineHeader';
 import { useInteractTimeline } from '@/page/archiving/index/hook/common/useInteractTimeline';
-import { Block } from '@/page/archiving/index/type/blockType';
 
 import ContentBox from '@/shared/component/ContentBox/ContentBox';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
@@ -23,7 +22,7 @@ const ArchivingPage = () => {
   const teamId = useInitializeTeamId();
 
   const location = useLocation();
-  const selectedBlockFromDashboard: Block = location.state?.selectedBlock;
+  const selectedBlockFromDashboard: TimeBlockData = location.state?.selectedBlock;
   const finalSelectedBlock = selectedBlockFromDashboard || selectedBlock;
 
   const { openDrawer } = useDrawerAction();
@@ -32,7 +31,7 @@ const ArchivingPage = () => {
     if (selectedBlockFromDashboard) {
       /** TODO: 추후 block id에 따른 API 응답으로 데이터 넣기 */
       openDrawer({
-        title: selectedBlockFromDashboard.name,
+        title: selectedBlockFromDashboard[0].name!,
         startDate: new Date('2024-09-13'),
         endDate: new Date('2024-09-24'),
         blockType: 'MEETING',

--- a/apps/client/src/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock.style.ts
+++ b/apps/client/src/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock.style.ts
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
 import { theme } from '@tiki/ui';
 
-import { BlockColor } from '@/page/archiving/index/type/color';
-
 export const blockStyle = (color: string, isSelected: boolean) =>
   css({
     display: 'flex',
@@ -30,7 +28,7 @@ export const blockStyle = (color: string, isSelected: boolean) =>
     cursor: 'pointer',
   });
 
-export const blockNameStyle = (background: BlockColor) =>
+export const blockNameStyle = (background: string) =>
   css({
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/apps/client/src/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock.tsx
+++ b/apps/client/src/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock.tsx
@@ -3,13 +3,12 @@ import React, { HTMLAttributes, ReactNode } from 'react';
 import { blockNameStyle, blockStyle } from '@/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock.style';
 import { BLOCK_ICON } from '@/page/archiving/index/constant/icon';
 import { BlockType } from '@/page/archiving/index/type/blockType';
-import { BlockColor } from '@/page/archiving/index/type/color';
 
 interface TimeBlockProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   startDate: Date;
   endDate: Date;
-  color: BlockColor;
+  color: string;
   floor: number;
   blockType: BlockType;
   isSelected?: boolean;

--- a/apps/client/src/page/archiving/index/hook/common/useInteractTimeline.ts
+++ b/apps/client/src/page/archiving/index/hook/common/useInteractTimeline.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-import { Block } from '@/page/archiving/index/type/blockType';
+import { TimeBlockData } from '@/page/archiving/index/component/TimeLine';
 
 import { useDrawerAction } from '@/shared/store/drawer';
 
 export const useInteractTimeline = () => {
-  const [selectedBlock, setSelectedBlock] = useState<Block>();
+  const [selectedBlock, setSelectedBlock] = useState<TimeBlockData>();
 
   const { openDrawer } = useDrawerAction();
 

--- a/apps/client/src/page/archiving/index/type/blockType.ts
+++ b/apps/client/src/page/archiving/index/type/blockType.ts
@@ -17,4 +17,4 @@ export interface TimeBlockList {
   };
 }
 
-export type BlockType = 'MEETING' | 'NOTICE' | 'ACCOUNTING' | 'TASK' | 'STUDY' | 'EVENT';
+export type BlockType = 'MEETING' | 'RECRUITING' | 'STUDY' | 'EVENT' | 'NOTICE' | 'ETC';

--- a/apps/client/src/page/archiving/index/util/block.ts
+++ b/apps/client/src/page/archiving/index/util/block.ts
@@ -1,4 +1,4 @@
-import { Block } from '@/page/archiving/index/type/blockType';
+import { TimeBlockData } from '@/page/archiving/index/component/TimeLine';
 
 interface Floors {
   [key: string]: number;
@@ -65,16 +65,16 @@ export const createTimeBlock = ({ startDate, endDate, currentYear, currentMonth 
 };
 
 // 타임블록의 상하 배치 함수
-export const alignBlocks = (data: Block[], endDay: Date, currentMonth: number, currentYear: number): Floors => {
-  const timeTable: boolean[][] = Array.from({ length: endDay.getDate() + 1 }, () => Array(data.length).fill(false));
+export const alignBlocks = (data: TimeBlockData, endDay: Date, currentMonth: number, currentYear: number): Floors => {
+  const timeTable: boolean[][] = Array.from({ length: endDay.getDate() + 1 }, () => Array(data!.length).fill(false));
   const floors: Floors = {};
 
-  data.forEach((block) => {
+  data?.forEach((block) => {
     const { startDate, endDate } = block;
 
     const { startDate: blockStartDate, endDate: blockEndDate } = createTimeBlock({
-      startDate: parseLocalDate(startDate.toString()),
-      endDate: parseLocalDate(endDate.toString()),
+      startDate: parseLocalDate(startDate!.toString()),
+      endDate: parseLocalDate(endDate!.toString()),
       currentYear,
       currentMonth,
     });
@@ -97,7 +97,7 @@ export const alignBlocks = (data: Block[], endDay: Date, currentMonth: number, c
             timeTable[day][depth] = true;
           }
         });
-        floors[block.timeBlockId] = depth;
+        floors[block.timeBlockId!] = depth;
         break;
       }
     }

--- a/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
@@ -4,11 +4,10 @@ import { useDateContext } from '@/page/archiving/index/DateProvider';
 import Day from '@/page/archiving/index/component/TimeLine/Day/Day';
 import { dayBodyStyle } from '@/page/archiving/index/component/TimeLine/Day/Day.style';
 import TimeBlock from '@/page/archiving/index/component/TimeLine/TimeBlock/TimeBlock';
-import { useGetTimeBlockQuery } from '@/page/archiving/index/hook/api/useGetTimeBlockQuery';
-import { Block } from '@/page/archiving/index/type/blockType';
 import { alignBlocks, createTimeBlock } from '@/page/archiving/index/util/block';
 import { timelineContentStyle } from '@/page/dashboard/component/Timeline/Timeline/Timeline.style';
 
+import { $api } from '@/shared/api/client';
 import { PATH } from '@/shared/constant/path';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 
@@ -19,20 +18,31 @@ const Timeline = () => {
 
   const { currentYear, currentMonth, endDay } = useDateContext();
 
-  const { data } = useGetTimeBlockQuery(teamId, 'executive', currentYear, currentMonth);
+  const { data } = $api.useSuspenseQuery('get', '/api/v1/teams/{teamId}/timeline', {
+    params: {
+      query: {
+        type: 'executive',
+        date: `${currentYear}-${currentMonth.toString().padStart(2, '0')}`,
+      },
+      path: {
+        teamId,
+      },
+    },
+  });
 
-  const timeBlocks: Block[] = data.timeBlocks;
+  const timeBlocks = data.data?.timeBlocks;
+
   const blockFloors = alignBlocks(timeBlocks, endDay, currentMonth, currentYear);
 
   return (
     <>
       <Day />
       <div css={[dayBodyStyle(endDay.getDate()), timelineContentStyle]}>
-        {timeBlocks.map((block) => {
+        {timeBlocks?.map((block) => {
           const { startDate, endDate } = block;
           const { startDate: blockStartDate, endDate: blockEndDate } = createTimeBlock({
-            startDate: new Date(startDate),
-            endDate: new Date(endDate),
+            startDate: startDate ? new Date(startDate) : new Date(),
+            endDate: endDate ? new Date(endDate) : new Date(),
             currentYear,
             currentMonth,
           });
@@ -42,9 +52,9 @@ const Timeline = () => {
               key={block.timeBlockId}
               startDate={blockStartDate}
               endDate={blockEndDate}
-              color={block.color}
-              floor={blockFloors[block.timeBlockId] || 1}
-              blockType={block.blockType}
+              color={block.color!}
+              floor={blockFloors[block.timeBlockId ?? 0]}
+              blockType={block.blockType ?? 'MEETING'}
               onBlockClick={() => {
                 navigate(PATH.ARCHIVING, { state: { selectedBlock: block } });
               }}>

--- a/apps/client/src/shared/__generated__/schema.d.ts
+++ b/apps/client/src/shared/__generated__/schema.d.ts
@@ -4,2794 +4,3289 @@
  */
 
 export interface paths {
-    "/api/v1/time-blocks/team/{teamId}/time-block": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 타임 블록 생성
-         * @description 타임 블록을 생성한다.
-         */
-        post: operations["createTimeBlock"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  '/api/v1/teams': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체 팀 조회
-         * @description 가입한 대학의 전체 팀을 조회한다.
-         */
-        get: operations["getAllTeams"];
-        put?: never;
-        /**
-         * 팀 생성
-         * @description 팀을 생성한다.
-         */
-        post: operations["createTeam"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체 팀 조회
+     * @description 가입한 대학의 전체 팀을 조회한다.
+     */
+    get: operations['getAllTeams'];
+    put?: never;
+    /**
+     * 팀 생성
+     * @description 팀을 생성한다.
+     */
+    post: operations['createTeam'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/trash': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/trash": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getTrash"];
-        put?: never;
-        post: operations["restore"];
-        delete: operations["deleteTrash"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 휴지통 조회
+     * @description 휴지통을 조회한다.
+     */
+    get: operations['getTrash'];
+    put?: never;
+    /**
+     * 휴지통 문서 복구
+     * @description 휴지통 속 문서를 여러 개 복구한다.
+     */
+    post: operations['restore'];
+    /**
+     * 휴지통 문서 삭제
+     * @description 휴지통 속 문서를 여러 개 삭제한다.
+     */
+    delete: operations['deleteTrash'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/folders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getFolders"];
-        put?: never;
-        post: operations["createFolder"];
-        delete: operations["delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 타임 블록 생성
+     * @description 타임 블록을 생성한다.
+     */
+    post: operations['createTimeBlock'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block/{timeBlockId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/documents": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getDocuments"];
-        put?: never;
-        post: operations["createDocuments"];
-        delete: operations["delete_1"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 타임 블록 상세 조회
+     * @description 타임 블록을 상세 조회한다.
+     */
+    get: operations['getTimeBlockDetail'];
+    put?: never;
+    /**
+     * 타임 블록 파일 태그 추가
+     * @description 타임 블록에 파일 태그를 추가한다.
+     */
+    post: operations['createDocumentTag'];
+    /**
+     * 타임 블록 삭제
+     * @description 타임 블록을 삭제한다.
+     */
+    delete: operations['deleteTimeBlock'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/folders': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/template": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["createNoteTemplate"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 폴더 조회
+     * @description 폴더를 여러 개 조회한다.
+     */
+    get: operations['getFolders'];
+    put?: never;
+    /**
+     * 폴더 생성
+     * @description 폴더를 생성한다.
+     */
+    post: operations['createFolder'];
+    /**
+     * 폴더 삭제
+     * @description 폴더를 여러 개 삭제한다.
+     */
+    delete: operations['delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/documents': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/free": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["createNoteFree"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 문서 조회
+     * @description 문서를 조회한다.
+     */
+    get: operations['getDocuments'];
+    put?: never;
+    /**
+     * 문서 생성
+     * @description 문서를 여러 개 생성한다.
+     */
+    post: operations['createDocuments'];
+    /**
+     * 문서 삭제
+     * @description 문서를 여러 개 삭제한다.
+     */
+    delete: operations['delete_1'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/template': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 회원가입 API
-         * @description 회원가입을 위한 정보를 보낸다.
-         */
-        post: operations["signUp"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations['createNoteTemplate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/free': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/file": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * s3 파일 삭제
-         * @description s3의 파일 삭제한다.
-         */
-        post: operations["deleteFile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations['createNoteFree'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/members': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/signup": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 회원가입 메일 전송
-         * @description 회원 가입을 진행한다.
-         */
-        post: operations["sendSignUpMail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 회원가입 API
+     * @description 회원가입을 위한 정보를 보낸다.
+     */
+    post: operations['signUp'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/file': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 비밀번호 재설정 메일 전송
-         * @description 비밀번호 재설정을 위한 이메일을 보낸다.
-         */
-        post: operations["sendChangingPasswordMail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * s3 파일 삭제
+     * @description s3의 파일 삭제한다.
+     */
+    post: operations['deleteFile'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/signup': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/checking": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 메일 인증
-         * @description 인증번호 확인
-         */
-        post: operations["checkCode"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 회원가입 메일 전송
+     * @description 회원 가입을 진행한다.
+     */
+    post: operations['sendSignUpMail'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/password': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/auth/sign-in": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 로그인
-         * @description 로그인을 진행한다.
-         */
-        post: operations["signIn"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 비밀번호 재설정 메일 전송
+     * @description 비밀번호 재설정을 위한 이메일을 보낸다.
+     */
+    post: operations['sendChangingPasswordMail'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/checking': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/name": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateTeamName"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 메일 인증
+     * @description 인증번호 확인
+     */
+    post: operations['checkCode'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/auth/sign-in': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/member/{targetId}/admin": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["alterAdmin"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 로그인
+     * @description 로그인을 진행한다.
+     */
+    post: operations['signIn'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/name': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/icon": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateIconImage"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateTeamName'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/member/{targetId}/admin': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/folders/{folderId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateFolderName"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['alterAdmin'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/icon': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/name": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateTeamMemberName"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateIconImage'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/folders/{folderId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/template/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateNoteTemplate"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 폴더 이름 수정
+     * @description 폴더 이름을 수정한다.
+     */
+    patch: operations['updateFolderName'];
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/name': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/free/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateNoteFree"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateTeamMemberName'];
+    trace?: never;
+  };
+  '/api/v1/notes/template/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 비밀번호 변경
-         * @description 비밀번호를 변경합니다.
-         */
-        patch: operations["changePassword"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateNoteTemplate'];
+    trace?: never;
+  };
+  '/api/v1/notes/free/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/time-blocks/team/{teamId}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 타임라인 조회
-         * @description 타임라인을 조회한다.
-         */
-        get: operations["getTimeline"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateNoteFree'];
+    trace?: never;
+  };
+  '/api/v1/members/password': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/time-blocks/team/{teamId}/time-block/{timeBlockId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 타임 블록 상세 조회
-         * @description 타임 블록을 상세 조회한다.
-         */
-        get: operations["getTimeBlockDetail"];
-        put?: never;
-        post?: never;
-        /**
-         * 타임 블록 삭제
-         * @description 타임 블록을 삭제한다.
-         */
-        delete: operations["deleteTimeBlock"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 비밀번호 변경
+     * @description 비밀번호를 변경합니다.
+     */
+    patch: operations['changePassword'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/timeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/category": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 카테고리 조회
-         * @description 카테고리 리스트를 조회한다.
-         */
-        get: operations["getCategories"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 타임라인 조회
+     * @description 타임라인을 조회한다.
+     */
+    get: operations['getTimeline'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/capacity': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/position": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getMemberTeamPosition"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 팀 용량 정보 조회
+     * @description 팀 용량 정보를 조회한다.
+     */
+    get: operations['getCapacityInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/category': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/{teamId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getNote"];
-        put?: never;
-        post?: never;
-        delete: operations["deleteNotes"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 카테고리 조회
+     * @description 카테고리 리스트를 조회한다.
+     */
+    get: operations['getCategories'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/position': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/{teamId}/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getNoteDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getMemberTeamPosition'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/{teamId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 소속 팀 가져오기
-         * @description 왼쪽 사이드바의 소속된 팀 정보를 가져옵니다.
-         */
-        get: operations["getBelongTeam"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getNote'];
+    put?: never;
+    post?: never;
+    delete: operations['deleteNotes'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/{teamId}/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/file/upload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Presigned Url 생성
-         * @description s3로부터 Presigned Url을 생성한다.
-         */
-        get: operations["getPreSignedUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getNoteDetail'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/members/teams': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/documents/team/{teamId}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체 문서 조회
-         * @description 전체 문서를 조회한다.
-         */
-        get: operations["getAllDocuments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 소속 팀 가져오기
+     * @description 왼쪽 사이드바의 소속된 팀 정보를 가져옵니다.
+     */
+    get: operations['getBelongTeam'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/file/upload': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/auth/reissue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 엑세스 토큰 재발급
-         * @description 엑세스 토큰 재발급 메서드입니다.
-         */
-        get: operations["reissue"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Presigned Url 생성
+     * @description s3로부터 Presigned Url을 생성한다.
+     */
+    get: operations['getPreSignedUrl'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/documents/team/{teamId}/timeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * 팀 삭제
-         * @description 팀을 삭제한다.
-         */
-        delete: operations["deleteTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체 문서 조회
+     * @description 전체 문서를 조회한다.
+     */
+    get: operations['getAllDocuments'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/auth/reissue': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/{kickOutMemberId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete: operations["kickOutMemberFromTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 엑세스 토큰 재발급
+     * @description 엑세스 토큰 재발급 메서드입니다.
+     */
+    get: operations['reissue'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/leave": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete: operations["leaveTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * 팀 삭제
+     * @description 팀을 삭제한다.
+     */
+    delete: operations['deleteTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block/{timeBlockId}/tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/documents/team/{teamId}/document/{documentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * 문서 삭제
-         * @description 문서를 삭제한다.
-         */
-        delete: operations["deleteDocument"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * 타임 블록 파일 태그 삭제
+     * @description 타임 블록의 파일 태그를 삭제한다.
+     */
+    delete: operations['deleteDocumentTag'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/{kickOutMemberId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: operations['kickOutMemberFromTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/leave': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: operations['leaveTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        ErrorResponse: {
-            success?: boolean;
-            message?: string;
-        };
-        TimeBlockCreateRequest: {
-            name?: string;
-            color?: string;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            /** @enum {string} */
-            blockType?: "MEETING" | "ACCOUNTING" | "TASK" | "NOTICE" | "STUDY" | "EVENT";
-            files?: {
-                [key: string]: string;
-            };
-        };
-        SuccessResponseTimeBlockCreateResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["TimeBlockCreateResponse"];
-        };
-        TimeBlockCreateResponse: {
-            /** Format: int64 */
-            timeBlockId?: number;
-        };
-        TeamCreateRequest: {
-            name?: string;
-            /** @enum {string} */
-            category?: "전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹";
-            iconImageUrl?: string;
-        };
-        SuccessResponseTeamCreateResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["TeamCreateResponse"];
-        };
-        TeamCreateResponse: {
-            /** Format: int64 */
-            teamId?: number;
-        };
-        FolderCreateRequest: {
-            name?: string;
-        };
-        FolderCreateResponse: {
-            /** Format: int64 */
-            folderId?: number;
-        };
-        SuccessResponseFolderCreateResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["FolderCreateResponse"];
-        };
-        DocumentCreateRequest: {
-            fileName?: string;
-            fileUrl?: string;
-            /** Format: double */
-            capacity?: number;
-        };
-        DocumentsCreateRequest: {
-            documents?: components["schemas"]["DocumentCreateRequest"][];
-        };
-        SuccessResponseObject: {
-            success?: boolean;
-            message?: string;
-            data?: Record<string, never>;
-        };
-        NoteTemplateCreateRequest: {
-            title?: string;
-            complete?: boolean;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            answerWhatActivity?: string;
-            answerHowToPrepare?: string;
-            answerWhatIsDisappointedThing?: string;
-            answerHowToFix?: string;
-            timeBlockIds?: number[];
-            documentIds?: number[];
-            /** Format: int64 */
-            teamId?: number;
-        };
-        NoteCreateServiceResponse: {
-            /** Format: int64 */
-            noteId?: number;
-        };
-        SuccessResponseNoteCreateServiceResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["NoteCreateServiceResponse"];
-        };
-        NoteFreeCreateRequest: {
-            title?: string;
-            complete?: boolean;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            contents?: string;
-            timeBlockIds?: number[];
-            documentIds?: number[];
-            /** Format: int64 */
-            teamId?: number;
-        };
-        MemberProfileCreateRequest: {
-            name?: string;
-            /** Format: date */
-            birth?: string;
-            /** @enum {string} */
-            univ?: "건국대학교";
-            email?: string;
-            password?: string;
-            passwordChecker?: string;
-        };
-        BaseResponse: Record<string, never>;
-        S3DeleteRequest: {
-            fileName?: string;
-        };
-        EmailRequest: {
-            email?: string;
-        };
-        CodeVerificationRequest: {
-            email?: string;
-            code?: string;
-        };
-        SignInRequest: {
-            email?: string;
-            password?: string;
-        };
-        SignInGetResponse: {
-            accessToken?: string;
-            refreshToken?: string;
-        };
-        SuccessResponseSignInGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["SignInGetResponse"];
-        };
-        UpdateTeamNameRequest: {
-            newTeamName: string;
-        };
-        UpdateTeamIconRequest: {
-            iconImageUrl: string;
-        };
-        FolderNameUpdateRequest: {
-            name?: string;
-        };
-        UpdateTeamMemberNameRequest: {
-            newName: string;
-        };
-        NoteTemplateUpdateRequest: {
-            title?: string;
-            complete?: boolean;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            answerWhatActivity?: string;
-            answerHowToPrepare?: string;
-            answerWhatIsDisappointedThing?: string;
-            answerHowToFix?: string;
-            timeBlockIds?: number[];
-            documentIds?: number[];
-            /** Format: int64 */
-            teamId?: number;
-        };
-        NoteFreeUpdateRequest: {
-            title?: string;
-            complete?: boolean;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            contents?: string;
-            timeBlockIds?: number[];
-            documentIds?: number[];
-            /** Format: int64 */
-            teamId?: number;
-        };
-        PasswordChangeRequest: {
-            email?: string;
-            password?: string;
-            passwordChecker?: string;
-        };
-        SuccessResponseTimelineGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["TimelineGetResponse"];
-        };
-        TimeBlockGetResponse: {
-            /** Format: int64 */
-            timeBlockId?: number;
-            name?: string;
-            color?: string;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            /** @enum {string} */
-            blockType?: "MEETING" | "ACCOUNTING" | "TASK" | "NOTICE" | "STUDY" | "EVENT";
-        };
-        TimelineGetResponse: {
-            timeBlocks?: components["schemas"]["TimeBlockGetResponse"][];
-        };
-        DocumentGetResponse: {
-            /** Format: int64 */
-            documentId?: number;
-            fileName?: string;
-            fileUrl?: string;
-        };
-        NoteNameGetResponse: {
-            /** Format: int64 */
-            noteId?: number;
-            noteName?: string;
-        };
-        SuccessResponseTimeBlockDetailGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["TimeBlockDetailGetResponse"];
-        };
-        TimeBlockDetailGetResponse: {
-            documents?: components["schemas"]["DocumentGetResponse"][];
-            notes?: components["schemas"]["NoteNameGetResponse"][];
-        };
-        SuccessResponseTeamsGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["TeamsGetResponse"];
-        };
-        TeamGetResponse: {
-            /** Format: int64 */
-            teamId?: number;
-            name?: string;
-            /** @enum {string} */
-            category?: "전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹";
-            /** @enum {string} */
-            univ?: "건국대학교";
-            overview?: string;
-            imageUrl?: string;
-        };
-        TeamsGetResponse: {
-            teams?: components["schemas"]["TeamGetResponse"][];
-        };
-        DeletedDocumentGetResponse: {
-            /** Format: int64 */
-            documentId?: number;
-            name?: string;
-            url?: string;
-            /** Format: double */
-            capacity?: number;
-        };
-        DeletedDocumentsGetResponse: {
-            deletedDocuments?: components["schemas"]["DeletedDocumentGetResponse"][];
-        };
-        SuccessResponseDeletedDocumentsGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["DeletedDocumentsGetResponse"];
-        };
-        FolderGetResponse: {
-            /** Format: int64 */
-            id?: number;
-            name?: string;
-            /** Format: date-time */
-            createdTime?: string;
-            path?: string;
-        };
-        FoldersGetResponse: {
-            folders?: components["schemas"]["FolderGetResponse"][];
-        };
-        SuccessResponseFoldersGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["FoldersGetResponse"];
-        };
-        DocumentsGetResponse: {
-            documents?: components["schemas"]["DocumentGetResponse"][];
-        };
-        SuccessResponseDocumentsGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["DocumentsGetResponse"];
-        };
-        CategoriesGetResponse: {
-            categories?: ("전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹")[];
-        };
-        SuccessResponseCategoriesGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["CategoriesGetResponse"];
-        };
-        MemberTeamPositionGetResponse: {
-            /** @enum {string} */
-            position?: "ADMIN" | "EXECUTIVE" | "MEMBER";
-        };
-        SuccessResponseMemberTeamPositionGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["MemberTeamPositionGetResponse"];
-        };
-        NoteGetResponse: {
-            /** Format: int64 */
-            noteId?: number;
-            title?: string;
-            /** Format: date */
-            startDate?: string;
-            /** Format: date */
-            endDate?: string;
-            author?: string;
-            complete?: boolean;
-            /** Format: date-time */
-            lastUpdatedAt?: string;
-        };
-        NoteListGetServiceResponse: {
-            noteGetResponseList?: components["schemas"]["NoteGetResponse"][];
-        };
-        SuccessResponseNoteListGetServiceResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["NoteListGetServiceResponse"];
-        };
-        NoteDetailGetServiceResponse: Record<string, never>;
-        SuccessResponseNoteDetailGetServiceResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["NoteDetailGetServiceResponse"];
-        };
-        BelongTeamGetResponse: {
-            /** Format: int64 */
-            id?: number;
-            name?: string;
-            iconImageUrl?: string;
-        };
-        BelongTeamsGetResponse: {
-            belongTeamGetResponses?: components["schemas"]["BelongTeamGetResponse"][];
-        };
-        SuccessResponseBelongTeamsGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["BelongTeamsGetResponse"];
-        };
-        PreSignedUrlResponse: {
-            fileName?: string;
-            url?: string;
-        };
-        SuccessResponsePreSignedUrlResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["PreSignedUrlResponse"];
-        };
-        SuccessResponse: {
-            success?: boolean;
-            message?: string;
-            data?: Record<string, never>;
-        };
-        ReissueGetResponse: {
-            accessToken?: string;
-        };
-        SuccessResponseReissueGetResponse: {
-            success?: boolean;
-            message?: string;
-            data?: components["schemas"]["ReissueGetResponse"];
-        };
-        SuccessResponseVoid: {
-            success?: boolean;
-            message?: string;
-            data?: Record<string, never>;
-        };
+  schemas: {
+    ErrorResponse: {
+      success?: boolean;
+      message?: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    TeamCreateRequest: {
+      name?: string;
+      /** @enum {string} */
+      category?:
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹';
+      iconImageUrl?: string;
+    };
+    SuccessResponseTeamCreateResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['TeamCreateResponse'];
+    };
+    TeamCreateResponse: {
+      /** Format: int64 */
+      teamId?: number;
+    };
+    TimeBlockCreateRequest: {
+      name?: string;
+      color?: string;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      /** @enum {string} */
+      blockType?: 'MEETING' | 'RECRUITING' | 'STUDY' | 'EVENT' | 'NOTICE' | 'ETC';
+      documentIds?: number[];
+    };
+    SuccessResponseTimeBlockCreateResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['TimeBlockCreateResponse'];
+    };
+    TimeBlockCreateResponse: {
+      /** Format: int64 */
+      timeBlockId?: number;
+    };
+    SuccessResponseObject: {
+      success?: boolean;
+      message?: string;
+      data?: Record<string, never>;
+    };
+    FolderCreateRequest: {
+      /**
+       * @description 폴더 이름
+       * @example 폴더 1
+       */
+      name?: string;
+    };
+    FolderCreateResponse: {
+      /** Format: int64 */
+      folderId?: number;
+    };
+    SuccessResponseFolderCreateResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['FolderCreateResponse'];
+    };
+    DocumentCreateRequest: {
+      /**
+       * @description 파일 이름
+       * @example tiki.jpg
+       */
+      fileName?: string;
+      /**
+       * @description 파일 url
+       * @example https://.../tiki.jpg
+       */
+      fileUrl?: string;
+      /**
+       * @description 파일 key
+       * @example ....jpg
+       */
+      fileKey?: string;
+      /**
+       * Format: double
+       * @description 파일 용량
+       * @example 1.23
+       */
+      capacity?: number;
+    };
+    DocumentsCreateRequest: {
+      documents?: components['schemas']['DocumentCreateRequest'][];
+    };
+    NoteTemplateCreateRequest: {
+      title?: string;
+      complete?: boolean;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      answerWhatActivity?: string;
+      answerHowToPrepare?: string;
+      answerWhatIsDisappointedThing?: string;
+      answerHowToFix?: string;
+      timeBlockIds?: number[];
+      documentIds?: number[];
+      /** Format: int64 */
+      teamId?: number;
+    };
+    NoteCreateServiceResponse: {
+      /** Format: int64 */
+      noteId?: number;
+    };
+    SuccessResponseNoteCreateServiceResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['NoteCreateServiceResponse'];
+    };
+    NoteFreeCreateRequest: {
+      title?: string;
+      complete?: boolean;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      contents?: string;
+      timeBlockIds?: number[];
+      documentIds?: number[];
+      /** Format: int64 */
+      teamId?: number;
+    };
+    MemberProfileCreateRequest: {
+      name?: string;
+      /** Format: date */
+      birth?: string;
+      /** @enum {string} */
+      univ?: '건국대학교';
+      email?: string;
+      password?: string;
+      passwordChecker?: string;
+    };
+    BaseResponse: Record<string, never>;
+    S3DeleteRequest: {
+      fileKey?: string;
+    };
+    EmailRequest: {
+      email?: string;
+    };
+    CodeVerificationRequest: {
+      email?: string;
+      code?: string;
+    };
+    SignInRequest: {
+      email?: string;
+      password?: string;
+    };
+    SignInGetResponse: {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+    SuccessResponseSignInGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['SignInGetResponse'];
+    };
+    UpdateTeamNameRequest: {
+      newTeamName: string;
+    };
+    UpdateTeamIconRequest: {
+      iconImageUrl: string;
+    };
+    FolderNameUpdateRequest: {
+      /**
+       * @description 수정할 폴더 이름
+       * @example 수정할 폴더 1
+       */
+      name?: string;
+    };
+    UpdateTeamMemberNameRequest: {
+      newName: string;
+    };
+    NoteTemplateUpdateRequest: {
+      title?: string;
+      complete?: boolean;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      answerWhatActivity?: string;
+      answerHowToPrepare?: string;
+      answerWhatIsDisappointedThing?: string;
+      answerHowToFix?: string;
+      timeBlockIds?: number[];
+      documentIds?: number[];
+      /** Format: int64 */
+      teamId?: number;
+    };
+    NoteFreeUpdateRequest: {
+      title?: string;
+      complete?: boolean;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      contents?: string;
+      timeBlockIds?: number[];
+      documentIds?: number[];
+      /** Format: int64 */
+      teamId?: number;
+    };
+    PasswordChangeRequest: {
+      email?: string;
+      password?: string;
+      passwordChecker?: string;
+    };
+    SuccessResponseTeamsGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['TeamsGetResponse'];
+    };
+    TeamGetResponse: {
+      /** Format: int64 */
+      teamId?: number;
+      name?: string;
+      /** @enum {string} */
+      category?:
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹';
+      /** @enum {string} */
+      univ?: '건국대학교';
+      overview?: string;
+      imageUrl?: string;
+    };
+    TeamsGetResponse: {
+      teams?: components['schemas']['TeamGetResponse'][];
+    };
+    DeletedDocumentGetResponse: {
+      /** Format: int64 */
+      documentId?: number;
+      name?: string;
+      url?: string;
+      /** Format: double */
+      capacity?: number;
+    };
+    DeletedDocumentsGetResponse: {
+      deletedDocuments?: components['schemas']['DeletedDocumentGetResponse'][];
+    };
+    SuccessResponseDeletedDocumentsGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['DeletedDocumentsGetResponse'];
+    };
+    SuccessResponseTimelineGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['TimelineGetResponse'];
+    };
+    TimeBlockGetResponse: {
+      /** Format: int64 */
+      timeBlockId?: number;
+      name?: string;
+      color?: string;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      /** @enum {string} */
+      blockType?: 'MEETING' | 'RECRUITING' | 'STUDY' | 'EVENT' | 'NOTICE' | 'ETC';
+    };
+    TimelineGetResponse: {
+      timeBlocks?: components['schemas']['TimeBlockGetResponse'][];
+    };
+    DocumentGetResponse: {
+      /** Format: int64 */
+      documentId?: number;
+      fileName?: string;
+      fileUrl?: string;
+      /** Format: int64 */
+      tagId?: number;
+    };
+    NoteNameGetResponse: {
+      /** Format: int64 */
+      noteId?: number;
+      noteName?: string;
+    };
+    SuccessResponseTimeBlockDetailGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['TimeBlockDetailGetResponse'];
+    };
+    TimeBlockDetailGetResponse: {
+      documents?: components['schemas']['DocumentGetResponse'][];
+      notes?: components['schemas']['NoteNameGetResponse'][];
+    };
+    FolderGetResponse: {
+      /** Format: int64 */
+      id?: number;
+      name?: string;
+      /** Format: date-time */
+      createdTime?: string;
+      path?: string;
+    };
+    FoldersGetResponse: {
+      folders?: components['schemas']['FolderGetResponse'][];
+    };
+    SuccessResponseFoldersGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['FoldersGetResponse'];
+    };
+    DocumentsGetResponse: {
+      documents?: components['schemas']['DocumentGetResponse'][];
+    };
+    SuccessResponseDocumentsGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['DocumentsGetResponse'];
+    };
+    SuccessResponseUsageGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['UsageGetResponse'];
+    };
+    UsageGetResponse: {
+      /** Format: double */
+      capacity?: number;
+      /** Format: double */
+      usage?: number;
+    };
+    CategoriesGetResponse: {
+      categories?: (
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹'
+      )[];
+    };
+    SuccessResponseCategoriesGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['CategoriesGetResponse'];
+    };
+    MemberTeamPositionGetResponse: {
+      /** @enum {string} */
+      position?: 'ADMIN' | 'EXECUTIVE' | 'MEMBER';
+    };
+    SuccessResponseMemberTeamPositionGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['MemberTeamPositionGetResponse'];
+    };
+    NoteGetResponse: {
+      /** Format: int64 */
+      noteId?: number;
+      title?: string;
+      /** Format: date */
+      startDate?: string;
+      /** Format: date */
+      endDate?: string;
+      author?: string;
+      complete?: boolean;
+      /** Format: date-time */
+      lastUpdatedAt?: string;
+    };
+    NoteListGetServiceResponse: {
+      noteGetResponseList?: components['schemas']['NoteGetResponse'][];
+    };
+    SuccessResponseNoteListGetServiceResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['NoteListGetServiceResponse'];
+    };
+    NoteDetailGetServiceResponse: Record<string, never>;
+    SuccessResponseNoteDetailGetServiceResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['NoteDetailGetServiceResponse'];
+    };
+    BelongTeamGetResponse: {
+      /** Format: int64 */
+      id?: number;
+      name?: string;
+      iconImageUrl?: string;
+    };
+    BelongTeamsGetResponse: {
+      belongTeamGetResponses?: components['schemas']['BelongTeamGetResponse'][];
+    };
+    SuccessResponseBelongTeamsGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['BelongTeamsGetResponse'];
+    };
+    PreSignedUrlResponse: {
+      fileName?: string;
+      url?: string;
+    };
+    SuccessResponsePreSignedUrlResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['PreSignedUrlResponse'];
+    };
+    SuccessResponse: {
+      success?: boolean;
+      message?: string;
+      data?: Record<string, never>;
+    };
+    ReissueGetResponse: {
+      accessToken?: string;
+    };
+    SuccessResponseReissueGetResponse: {
+      success?: boolean;
+      message?: string;
+      data?: components['schemas']['ReissueGetResponse'];
+    };
+    SuccessResponseVoid: {
+      success?: boolean;
+      message?: string;
+      data?: Record<string, never>;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    createTimeBlock: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TimeBlockCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimeBlockCreateResponse"];
-                };
-            };
-            /** @description 타입 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  getAllTeams: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getAllTeams: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTeamsGetResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTeamsGetResponse'];
         };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    createTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TeamCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTeamCreateResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getTrash: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDeletedDocumentsGetResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TeamCreateRequest'];
+      };
     };
-    restore: {
-        parameters: {
-            query: {
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTeamCreateResponse'];
         };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteTrash: {
-        parameters: {
-            query: {
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-        };
+  };
+  getTrash: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getFolders: {
-        parameters: {
-            query?: {
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseFoldersGetResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDeletedDocumentsGetResponse'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    createFolder: {
-        parameters: {
-            query?: {
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FolderCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseFolderCreateResponse"];
-                };
-            };
-        };
+  };
+  restore: {
+    parameters: {
+      query: {
+        /**
+         * @description 복구할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    delete: {
-        parameters: {
-            query: {
-                folderId: number[];
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getDocuments: {
-        parameters: {
-            query?: {
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDocumentsGetResponse"];
-                };
-            };
-        };
+  };
+  deleteTrash: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    createDocuments: {
-        parameters: {
-            query?: {
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DocumentsCreateRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    delete_1: {
-        parameters: {
-            query: {
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-        };
+  };
+  createTimeBlock: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    createNoteTemplate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteTemplateCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteCreateServiceResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TimeBlockCreateRequest'];
+      };
     };
-    createNoteFree: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteFreeCreateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimeBlockCreateResponse'];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteCreateServiceResponse"];
-                };
-            };
+      };
+      /** @description 타입 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    signUp: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MemberProfileCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 비밀번호 불일치 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 이미 가입된 아이디 */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  getTimeBlockDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    deleteFile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["S3DeleteRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimeBlockDetailGetResponse'];
         };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description S3 버킷의 파일 삭제 실패 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    sendSignUpMail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 이미 가입된 아이디 */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createDocumentTag: {
+    parameters: {
+      query: {
+        /**
+         * @description 추가할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    sendChangingPasswordMail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 가입되지 않은 이메일 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    checkCode: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CodeVerificationRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 인증 값 불일치 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 인증 정보가 존재하지 않음 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteTimeBlock: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    signIn: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SignInRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseSignInGetResponse"];
-                };
-            };
-            /** @description 일치하지 않은 비밀번호 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateTeamName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateTeamNameRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  getFolders: {
+    parameters: {
+      query?: {
+        /**
+         * @description 조회할 폴더 id
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    alterAdmin: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                targetId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseFoldersGetResponse'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateIconImage: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateTeamIconRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  createFolder: {
+    parameters: {
+      query?: {
+        /**
+         * @description 생성할 폴더가 속할 폴더 id
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    updateFolderName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                folderId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FolderNameUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FolderCreateRequest'];
+      };
     };
-    updateTeamMemberName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateTeamMemberNameRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseFolderCreateResponse'];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateNoteTemplate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                noteId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteTemplateUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  delete: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 폴더 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        folderId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    updateNoteFree: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                noteId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteFreeUpdateRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    changePassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PasswordChangeRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 비밀번호가 일치하지 않습니다. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  getDocuments: {
+    parameters: {
+      query?: {
+        /**
+         * @description 조회할 폴더 id
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getTimeline: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-                /**
-                 * @description 조회할 타임라인의 년도와 월 정보
-                 * @example 2024-07
-                 */
-                date: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimelineGetResponse"];
-                };
-            };
-            /** @description 타입 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDocumentsGetResponse'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getTimeBlockDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimeBlockDetailGetResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createDocuments: {
+    parameters: {
+      query?: {
+        /**
+         * @description 생성할 파일이 속할 폴더 id
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    deleteTimeBlock: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DocumentsCreateRequest'];
+      };
     };
-    getCategories: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseCategoriesGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getMemberTeamPosition: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseMemberTeamPositionGetResponse"];
-                };
-            };
-        };
+  };
+  delete_1: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getNote: {
-        parameters: {
-            query?: {
-                createdAt?: string;
-                sortOrder?: "ASC" | "DESC";
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteListGetServiceResponse"];
-                };
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteNotes: {
-        parameters: {
-            query: {
-                noteIds: number[];
-            };
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
-        };
+  };
+  createNoteTemplate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getNoteDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                noteId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteDetailGetServiceResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteTemplateCreateRequest'];
+      };
     };
-    getBelongTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseBelongTeamsGetResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteCreateServiceResponse'];
         };
+      };
     };
-    getPreSignedUrl: {
-        parameters: {
-            query: {
-                /**
-                 * @description 파일 형식
-                 * @example hwp, pdf, ...
-                 */
-                fileFormat: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePreSignedUrlResponse"];
-                };
-            };
-            /** @description S3 PRESIGNED URL 불러오기 실패 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createNoteFree: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getAllDocuments: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDocumentsGetResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteFreeCreateRequest'];
+      };
     };
-    reissue: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseReissueGetResponse"];
-                };
-            };
-            /** @description 인증되지 않은 사용자 */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteCreateServiceResponse'];
         };
+      };
     };
-    deleteTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  signUp: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    kickOutMemberFromTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                kickOutMemberId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberProfileCreateRequest'];
+      };
     };
-    leaveTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
         };
+      };
+      /** @description 비밀번호 불일치 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 이미 가입된 아이디 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteDocument: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 문서 id
-                 * @example 1
-                 */
-                documentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 문서 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteFile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['S3DeleteRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description S3 버킷의 파일 삭제 실패 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  sendSignUpMail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 이미 가입된 아이디 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  sendChangingPasswordMail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 가입되지 않은 이메일 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  checkCode: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CodeVerificationRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 인증 값 불일치 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 인증 정보가 존재하지 않음 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  signIn: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SignInRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseSignInGetResponse'];
+        };
+      };
+      /** @description 일치하지 않은 비밀번호 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateTeamName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateTeamNameRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  alterAdmin: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+        targetId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateIconImage: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateTeamIconRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateFolderName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 수정할 폴더 id
+         * @example 1
+         */
+        folderId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FolderNameUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateTeamMemberName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateTeamMemberNameRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateNoteTemplate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteTemplateUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateNoteFree: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteFreeUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  changePassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PasswordChangeRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 비밀번호가 일치하지 않습니다. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getTimeline: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+        /**
+         * @description 조회할 타임라인의 년도와 월 정보
+         * @example 2024-07
+         */
+        date: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimelineGetResponse'];
+        };
+      };
+      /** @description 타입 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCapacityInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseUsageGetResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCategories: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseCategoriesGetResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getMemberTeamPosition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseMemberTeamPositionGetResponse'];
+        };
+      };
+    };
+  };
+  getNote: {
+    parameters: {
+      query?: {
+        createdAt?: string;
+        sortOrder?: 'ASC' | 'DESC';
+      };
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteListGetServiceResponse'];
+        };
+      };
+    };
+  };
+  deleteNotes: {
+    parameters: {
+      query: {
+        noteIds: number[];
+      };
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseVoid'];
+        };
+      };
+    };
+  };
+  getNoteDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteDetailGetServiceResponse'];
+        };
+      };
+    };
+  };
+  getBelongTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseBelongTeamsGetResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPreSignedUrl: {
+    parameters: {
+      query: {
+        /**
+         * @description 파일 형식
+         * @example hwp, pdf, ...
+         */
+        fileFormat: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponsePreSignedUrlResponse'];
+        };
+      };
+      /** @description S3 PRESIGNED URL 불러오기 실패 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getAllDocuments: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDocumentsGetResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  reissue: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseReissueGetResponse'];
+        };
+      };
+      /** @description 유효하지 않은 키, 인증되지 않은 사용자 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteDocumentTag: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 태그 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        tagId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  kickOutMemberFromTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+        kickOutMemberId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  leaveTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
 }


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #338 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- 타임라인에서 timeblock을 가져오는 api의 path가 변경된 것을 반영했습니다.
- 당장 다른 뷰를 개발하기에 `dashboard`에서 500에러가 뜨는 바람에 우선적으로 해당 페이지와 `archiving`페이지의 timeblock 정보 가져오는 부분을 수정했습니다.
- timeblock 생성 모달 부분도 현재 같은 문제로 500에러가 뜨는데, 채원이 모달 pr 머지되고 진행하는 게 나을 것 같아서 수정하지 않았습니다 !



### oas를 통한 타입 수정 
```tsx
import { components } from '@/shared/__generated__/schema';

export type TimeBlockData = components['schemas']['TimelineGetResponse']['timeBlocks'];
```

<img width="703" alt="스크린샷 2024-12-15 오후 9 30 46" src="https://github.com/user-attachments/assets/c3e6cd1c-6ae8-43aa-94e3-079e3f97a713" />

받아온 데이터의 상세 타입이 정의되어 있는 components를 통해 타입을 다시 지정해줬습니다.
기존에는 Block 타입을 따로 지정해줬으나, 해당 타입이 swagger 타입과 다른 부분이 조금 있어서 모두 `TimeBlockData`타입으로 수정해줬습니다.

---

## 📌스크린샷 (선택)
