### PR TITLE
[Fix] Team Id 초기화 오류 해결

### DIFF
--- a/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
@@ -1,3 +1,5 @@
+import { Button, Flex } from '@tiki/ui';
+
 import { useNavigate } from 'react-router-dom';
 
 import { useDateContext } from '@/page/archiving/index/DateProvider';
@@ -15,6 +17,26 @@ const Timeline = () => {
   const navigate = useNavigate();
 
   const teamId = useInitializeTeamId();
+
+  // teamId가 0이면 (가입되어 있는 팀이 없으면) 대체 뷰를 렌더링
+  if (teamId === 0) {
+    return (
+      <Flex styles={{ justify: 'center', align: 'center', direction: 'column' }}>
+        <h2>소속된 팀이 없습니다.</h2>
+        <Button
+          onClick={() => navigate(PATH.ROOT)}
+          css={{
+            marginTop: '1rem',
+            padding: '0.5rem 1rem',
+            borderRadius: '4px',
+            border: 'none',
+            cursor: 'pointer',
+          }}>
+          랜딩페이지로 이동
+        </Button>
+      </Flex>
+    );
+  }
 
   const { currentYear, currentMonth, endDay } = useDateContext();
 

--- a/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
@@ -18,6 +18,8 @@ const Timeline = () => {
 
   const teamId = useInitializeTeamId();
 
+  const { currentYear, currentMonth, endDay } = useDateContext();
+
   // teamId가 0이면 (가입되어 있는 팀이 없으면) 대체 뷰를 렌더링
   if (teamId === 0) {
     return (
@@ -37,8 +39,6 @@ const Timeline = () => {
       </Flex>
     );
   }
-
-  const { currentYear, currentMonth, endDay } = useDateContext();
 
   const { data } = $api.useSuspenseQuery('get', '/api/v1/teams/{teamId}/timeline', {
     params: {

--- a/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@tiki/ui';
+import { Button, Flex, Text } from '@tiki/ui';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -22,7 +22,7 @@ const Timeline = () => {
   if (teamId === 0) {
     return (
       <Flex styles={{ justify: 'center', align: 'center', direction: 'column' }}>
-        <h2>소속된 팀이 없습니다.</h2>
+        <Text>소속된 팀이 없습니다.</Text>
         <Button
           onClick={() => navigate(PATH.ROOT)}
           css={{

--- a/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
+++ b/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
@@ -7,14 +7,19 @@ type TeamResponse = paths['/api/v1/teams']['get']['responses']['200']['content']
 export const useInitializeTeamId = () => {
   const { setTeamId } = useTeamIdAction();
 
-  const { data, isSuccess } = $api.useQuery('get', '/api/v1/teams', {
+  const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams', {
     select: (response: TeamResponse) => {
       return response.data;
     },
   });
 
   if (isSuccess && !localStorage.getItem('teamId')) {
-    const teamId = (data?.data?.teams && data?.data.teams[0]?.teamId) ?? 0;
+    // 소속된 팀이 없는 경우 0 반환
+    if (data.data?.belongTeamGetResponses.length === 0) {
+      return 0;
+    }
+
+    const teamId = data.data?.belongTeamGetResponses[0].id ?? 0;
     localStorage.setItem('teamId', teamId!.toString());
 
     setTeamId(teamId);


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #361 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---
## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

팀 아이디 nullable 값 방지를 위해 팀 아이디가 없는 경우 0으로 저장해주는 방식으로 useInitializeTeamId 훅이 동작 중인데,
팀 아이디가 0인 경우 에러가 나서 에러페이지로 라우팅이 되는 문제가 있었습니다.

팀 아이디가 0인 경우에 에러페이지로 라우팅이 되지 않도록 대시보드에서 막아줘야 하기 때문에 팀 아이디가 0인 경우 임의의 뷰로 변경해주었습니다.
보우니가 디자인측에서 뷰 전달 받은 뒤 변경해주면 좋을 것 같습니다 !!

---

## 📌스크린샷 (선택)

<img width="1512" alt="스크린샷 2024-12-29 오후 2 27 29" src="https://github.com/user-attachments/assets/ea7276f6-848c-4450-9580-ef28c8c0af16" />
