### PR TITLE
[Feat] 파일/폴더 추가 API 연결

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -27,7 +27,8 @@
     "openapi-react-query": "^0.2.8",
     "openapi-typescript": "^7.4.4",
     "react-hook-form": "^7.53.1",
-    "react-router-dom": "^6.24.1"
+    "react-router-dom": "^6.24.1",
+    "use-query-params": "^2.2.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 import * as Sentry from '@sentry/react';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import { Outlet, useNavigate } from 'react-router-dom';
 
@@ -47,15 +49,17 @@ const App = () => {
 
   return (
     <ErrorBoundary fallback={ErrorPage} onReset={handleResetError}>
-      <ModalContainer />
-      <SideNavBar />
-      <div css={layoutStyle}>
-        <main css={outletStyle}>
-          <Header />
-          <Outlet />
-        </main>
-        <TimeBlockDrawer />
-      </div>
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <ModalContainer />
+        <SideNavBar />
+        <div css={layoutStyle}>
+          <main css={outletStyle}>
+            <Header />
+            <Outlet />
+          </main>
+          <TimeBlockDrawer />
+        </div>
+      </QueryParamProvider>
     </ErrorBoundary>
   );
 };

--- a/apps/client/src/page/archiving/index/component/TimeBlockModal/hook/common/useFile.tsx
+++ b/apps/client/src/page/archiving/index/component/TimeBlockModal/hook/common/useFile.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react';
 
 import { usePutUploadMutation } from '@/page/archiving/index/component/TimeBlockModal/hook/api/usePutUploadMutation';
 
-import { getFile } from '@/shared/api/file/upload';
+import { getPresignedUrl } from '@/shared/api/file/upload';
 import { Files } from '@/shared/api/time-blocks/team/time-block/type';
 import { extractFileExtension } from '@/shared/util/file';
 
@@ -32,7 +32,7 @@ const useFile = ({ files, onFilesChange, setFileUrls, setUploadStatus }: useFile
       for (let index = 0; index < uniqueNewFiles.length; index++) {
         const file = uniqueNewFiles[index];
         const fileExtension = extractFileExtension(file.name);
-        const fileData = await getFile(fileExtension);
+        const fileData = await getPresignedUrl(fileExtension);
         const fileName = file.name;
         newUploadStatus[fileName] = false;
         setUploadStatus((prevStatus) => ({ ...prevStatus, ...newUploadStatus }));

--- a/apps/client/src/page/drive/hook/api/queries.ts
+++ b/apps/client/src/page/drive/hook/api/queries.ts
@@ -1,14 +1,23 @@
 import { $api } from '@/shared/api/client';
 import { useTeamId } from '@/shared/store/team';
 
-export const useDriveData = () => {
+export const useDriveData = (folderId?: number | null) => {
   const teamId = useTeamId();
 
-  return $api.useSuspenseQuery('get', '/api/v1/teams/{teamId}/drive', {
+  if (folderId === null) folderId = undefined;
+
+  return $api.useQuery('get', '/api/v1/teams/{teamId}/drive', {
     params: {
       path: {
         teamId,
       },
+      query: {
+        folderId,
+      },
     },
   });
+};
+
+export const useUploadFile = () => {
+  return $api.useMutation('post', '/api/v1/teams/{teamId}/documents');
 };

--- a/apps/client/src/page/drive/hook/api/queries.ts
+++ b/apps/client/src/page/drive/hook/api/queries.ts
@@ -1,5 +1,12 @@
+import { useToastAction } from '@tiki/ui';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { components } from '@/shared/__generated__/schema';
 import { $api } from '@/shared/api/client';
 import { useTeamId } from '@/shared/store/team';
+
+export type CreateFileRequest = components['schemas']['DocumentCreateRequest'];
 
 export const useDriveData = (folderId?: number | null) => {
   const teamId = useTeamId();
@@ -19,5 +26,16 @@ export const useDriveData = (folderId?: number | null) => {
 };
 
 export const useUploadFile = () => {
-  return $api.useMutation('post', '/api/v1/teams/{teamId}/documents');
+  const { createToast } = useToastAction();
+
+  const queryClient = useQueryClient();
+
+  return $api.useMutation('post', '/api/v1/teams/{teamId}/documents', {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/v1/teams/{teamId}/drive'] });
+    },
+    onError: () => {
+      createToast('실패', 'error');
+    },
+  });
 };

--- a/apps/client/src/page/drive/hook/api/queries.ts
+++ b/apps/client/src/page/drive/hook/api/queries.ts
@@ -4,12 +4,12 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { components } from '@/shared/__generated__/schema';
 import { $api } from '@/shared/api/client';
-import { useTeamId } from '@/shared/store/team';
+import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 
 export type CreateFileRequest = components['schemas']['DocumentCreateRequest'];
 
 export const useDriveData = (folderId?: number | null) => {
-  const teamId = useTeamId();
+  const teamId = useInitializeTeamId();
 
   if (folderId === null) folderId = undefined;
 
@@ -25,14 +25,17 @@ export const useDriveData = (folderId?: number | null) => {
   });
 };
 
-export const useUploadFile = () => {
+export const useUploadFile = (folderId?: number | null) => {
   const { createToast } = useToastAction();
 
   const queryClient = useQueryClient();
+  const teamId = useInitializeTeamId();
 
   return $api.useMutation('post', '/api/v1/teams/{teamId}/documents', {
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/v1/teams/{teamId}/drive'] });
+      queryClient.invalidateQueries({
+        queryKey: ['get', '/api/v1/teams/{teamId}/drive', { params: { path: { teamId }, query: { folderId } } }],
+      });
     },
     onError: () => {
       createToast('실패', 'error');

--- a/apps/client/src/page/drive/index.style.ts
+++ b/apps/client/src/page/drive/index.style.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { theme } from '@tiki/ui';
 
 export const contentStyle = (length: number) =>
   css({
@@ -20,3 +21,22 @@ export const contentStyle = (length: number) =>
       gridTemplateColumns: length > 3 ? 'repeat(3, 1fr)' : '',
     },
   });
+
+export const uploadLabelStyle = css({
+  padding: '1.2rem 1.4rem',
+
+  borderRadius: '8px',
+  backgroundColor: theme.colors.key_500,
+
+  color: theme.colors.white,
+  ...theme.text.body08,
+
+  whiteSpace: 'nowrap',
+
+  transition: 'all .2s ease-in',
+  '&:hover': {
+    backgroundColor: theme.colors.key_600,
+
+    cursor: 'pointer',
+  },
+});

--- a/apps/client/src/page/drive/index.tsx
+++ b/apps/client/src/page/drive/index.tsx
@@ -8,7 +8,7 @@ import { ChangeEvent, useState } from 'react';
 import FileListHeader from '@/page/drive/component/FileListHeader/FileListHeader';
 import FileListItem from '@/page/drive/component/FileListItem/FileListItem';
 import FolderListItem from '@/page/drive/component/FileListItem/FolderListItem';
-import { useDriveData, useUploadFile } from '@/page/drive/hook/api/queries';
+import { CreateFileRequest, useDriveData, useUploadFile } from '@/page/drive/hook/api/queries';
 import { useSelectDocuments } from '@/page/drive/hook/common/useSelectDocuments';
 import { contentStyle, uploadLabelStyle } from '@/page/drive/index.style';
 import { DocumentItem, FilterOption, FolderItem } from '@/page/drive/type';
@@ -19,6 +19,7 @@ import FileGrid from '@/shared/component/FileGrid/FileGrid';
 import FolderGrid from '@/shared/component/FileGrid/FolderGrid';
 import { useTeamId } from '@/shared/store/team';
 import { File } from '@/shared/type/file';
+import { extractFileExtension } from '@/shared/util/file';
 
 import { FileData } from '@/mock/data/drive';
 
@@ -73,7 +74,16 @@ const DrivePage = () => {
   };
 
   const handleChangeFile = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log(e.target.files);
+    if (!e.target.files || e.target.files.length === 0) return;
+
+    const fileList = e.target.files;
+
+    const requestData: CreateFileRequest[] = Array.from({ length: fileList.length }).map((_, i) => ({
+      fileName: fileList[i].name,
+      fileUrl: 'https://ti-kii.com',
+      fileKey: 'jpg',
+      capacity: fileList[i].size,
+    }));
 
     mutate({
       params: {
@@ -81,11 +91,11 @@ const DrivePage = () => {
           teamId,
         },
         query: {
-          folderId: 0,
+          folderId: folderId === null ? undefined : folderId,
         },
       },
       body: {
-        documents: [],
+        documents: requestData,
       },
     });
   };
@@ -210,7 +220,7 @@ const DrivePage = () => {
                   key={file.documentId}
                   name={file.name}
                   capacity={file.capacity}
-                  type={file.url?.split('.').at(-1) as File}
+                  type={extractFileExtension(file.url) as File}
                   url={file.url}
                   createdTime={file.createdTime}
                   isSelected={getDocumentIsSelected(file.documentId)}

--- a/apps/client/src/shared/__generated__/schema.d.ts
+++ b/apps/client/src/shared/__generated__/schema.d.ts
@@ -4,3764 +4,3800 @@
  */
 
 export interface paths {
-    "/api/v1/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체 팀 조회
-         * @description 가입한 대학의 전체 팀을 조회한다.
-         */
-        get: operations["getAllTeams"];
-        put?: never;
-        /**
-         * 팀 생성
-         * @description 팀을 생성한다.
-         */
-        post: operations["createTeam"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  '/api/v1/teams': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/trash": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 휴지통 조회
-         * @description 휴지통을 조회한다.
-         */
-        get: operations["getTrash"];
-        put?: never;
-        /**
-         * 휴지통 문서 복구
-         * @description 휴지통 속 문서를 여러 개 복구한다.
-         */
-        post: operations["restore"];
-        /**
-         * 휴지통 문서 삭제
-         * @description 휴지통 속 문서를 여러 개 삭제한다.
-         */
-        delete: operations["deleteTrash"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체 팀 조회
+     * @description 가입한 대학의 전체 팀을 조회한다.
+     */
+    get: operations['getAllTeams'];
+    put?: never;
+    /**
+     * 팀 생성
+     * @description 팀을 생성한다.
+     */
+    post: operations['createTeam'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/trash': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/time-block": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 타임 블록 생성
-         * @description 타임 블록을 생성한다.
-         */
-        post: operations["createTimeBlock"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 휴지통 조회
+     * @description 휴지통을 조회한다.
+     */
+    get: operations['getTrash'];
+    put?: never;
+    /**
+     * 휴지통 문서 복구
+     * @description 휴지통 속 문서를 여러 개 복구한다.
+     */
+    post: operations['restore'];
+    /**
+     * 휴지통 문서 삭제
+     * @description 휴지통 속 문서를 여러 개 삭제한다.
+     */
+    delete: operations['deleteTrash'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/time-block/{timeBlockId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 타임 블록 상세 조회
-         * @description 타임 블록을 상세 조회한다.
-         */
-        get: operations["getTimeBlockDetail"];
-        put?: never;
-        /**
-         * 타임 블록 파일 태그 추가
-         * @description 타임 블록에 파일 태그를 추가한다.
-         */
-        post: operations["createDocumentTag"];
-        /**
-         * 타임 블록 삭제
-         * @description 타임 블록을 삭제한다.
-         */
-        delete: operations["deleteTimeBlock"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 타임 블록 생성
+     * @description 타임 블록을 생성한다.
+     */
+    post: operations['createTimeBlock'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block/{timeBlockId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/folders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 폴더 조회
-         * @description 폴더를 여러 개 조회한다.
-         */
-        get: operations["getFolders"];
-        put?: never;
-        /**
-         * 폴더 생성
-         * @description 폴더를 생성한다.
-         */
-        post: operations["createFolder"];
-        /**
-         * 폴더 삭제
-         * @description 폴더를 여러 개 삭제한다.
-         */
-        delete: operations["delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 타임 블록 상세 조회
+     * @description 타임 블록을 상세 조회한다.
+     */
+    get: operations['getTimeBlockDetail'];
+    put?: never;
+    /**
+     * 타임 블록 파일 태그 추가
+     * @description 타임 블록에 파일 태그를 추가한다.
+     */
+    post: operations['createDocumentTag'];
+    /**
+     * 타임 블록 삭제
+     * @description 타임 블록을 삭제한다.
+     */
+    delete: operations['deleteTimeBlock'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/folders': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/documents": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 문서 조회
-         * @description 문서를 조회한다.
-         */
-        get: operations["getDocuments"];
-        put?: never;
-        /**
-         * 문서 생성
-         * @description 문서를 여러 개 생성한다.
-         */
-        post: operations["createDocuments"];
-        /**
-         * 문서 삭제
-         * @description 문서를 여러 개 삭제한다.
-         */
-        delete: operations["delete_1"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 폴더 조회
+     * @description 폴더를 여러 개 조회한다.
+     */
+    get: operations['getFolders'];
+    put?: never;
+    /**
+     * 폴더 생성
+     * @description 폴더를 생성한다.
+     */
+    post: operations['createFolder'];
+    /**
+     * 폴더 삭제
+     * @description 폴더를 여러 개 삭제한다.
+     */
+    delete: operations['delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/documents': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/template": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 템플릿 노트 생성
-         * @description 새로운 템플릿 형식 노트를 생성한다.
-         */
-        post: operations["createNoteTemplate"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 문서 조회
+     * @description 문서를 조회한다.
+     */
+    get: operations['getDocuments'];
+    put?: never;
+    /**
+     * 문서 생성
+     * @description 문서를 여러 개 생성한다.
+     */
+    post: operations['createDocuments'];
+    /**
+     * 문서 삭제
+     * @description 문서를 여러 개 삭제한다.
+     */
+    delete: operations['delete_1'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/template': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/free": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 자유 형식 노트 생성
-         * @description 새로운 자유 형식 노트를 생성한다.
-         */
-        post: operations["createNoteFree"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 템플릿 노트 생성
+     * @description 새로운 템플릿 형식 노트를 생성한다.
+     */
+    post: operations['createNoteTemplate'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/free': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 회원가입 API
-         * @description 회원가입을 위한 정보를 보낸다.
-         */
-        post: operations["signUp"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 자유 형식 노트 생성
+     * @description 새로운 자유 형식 노트를 생성한다.
+     */
+    post: operations['createNoteFree'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/members': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/file": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * s3 파일 삭제
-         * @description s3의 파일 삭제한다.
-         */
-        post: operations["deleteFile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 회원가입 API
+     * @description 회원가입을 위한 정보를 보낸다.
+     */
+    post: operations['signUp'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/file': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/signup": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 회원가입 메일 전송
-         * @description 회원 가입을 진행한다.
-         */
-        post: operations["sendSignUpMail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * s3 파일 삭제
+     * @description s3의 파일 삭제한다.
+     */
+    post: operations['deleteFile'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/signup': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 비밀번호 재설정 메일 전송
-         * @description 비밀번호 재설정을 위한 이메일을 보낸다.
-         */
-        post: operations["sendChangingPasswordMail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 회원가입 메일 전송
+     * @description 회원 가입을 진행한다.
+     */
+    post: operations['sendSignUpMail'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/password': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/email-verification/checking": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 메일 인증
-         * @description 인증번호 확인
-         */
-        post: operations["checkCode"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 비밀번호 재설정 메일 전송
+     * @description 비밀번호 재설정을 위한 이메일을 보낸다.
+     */
+    post: operations['sendChangingPasswordMail'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/email-verification/checking': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/auth/sign-in": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 로그인
-         * @description 로그인을 진행한다.
-         */
-        post: operations["signIn"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 메일 인증
+     * @description 인증번호 확인
+     */
+    post: operations['checkCode'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/auth/sign-in': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/member/{targetId}/admin": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["alterAdmin"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * 로그인
+     * @description 로그인을 진행한다.
+     */
+    post: operations['signIn'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/member/{targetId}/admin': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/inform": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getTeamName"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateTeamAndTeamMemberInform"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['alterAdmin'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/inform': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/folders/{folderId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 폴더 이름 수정
-         * @description 폴더 이름을 수정한다.
-         */
-        patch: operations["updateFolderName"];
-        trace?: never;
+    get: operations['getTeamName'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateTeamAndTeamMemberInform'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/folders/{folderId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/name": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: operations["updateTeamMemberName"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 폴더 이름 수정
+     * @description 폴더 이름을 수정한다.
+     */
+    patch: operations['updateFolderName'];
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/name': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/template/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 템플릿 노트 수정
-         * @description 기존 템플릿 노트를 수정한다.
-         */
-        patch: operations["updateNoteTemplate"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations['updateTeamMemberName'];
+    trace?: never;
+  };
+  '/api/v1/notes/template/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/free/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 자유 형식 노트 수정
-         * @description 기존 자유 형식 노트를 수정한다.
-         */
-        patch: operations["updateNoteFree"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 템플릿 노트 수정
+     * @description 기존 템플릿 노트를 수정한다.
+     */
+    patch: operations['updateNoteTemplate'];
+    trace?: never;
+  };
+  '/api/v1/notes/free/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * 비밀번호 변경
-         * @description 비밀번호를 변경합니다.
-         */
-        patch: operations["changePassword"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 자유 형식 노트 수정
+     * @description 기존 자유 형식 노트를 수정한다.
+     */
+    patch: operations['updateNoteFree'];
+    trace?: never;
+  };
+  '/api/v1/members/password': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 타임라인 조회
-         * @description 타임라인을 조회한다.
-         */
-        get: operations["getTimeline"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * 비밀번호 변경
+     * @description 비밀번호를 변경합니다.
+     */
+    patch: operations['changePassword'];
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/timeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/drive": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 드라이브 조회
-         * @description 드라이브 뷰를 조회한다.
-         */
-        get: operations["getDrive"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 타임라인 조회
+     * @description 타임라인을 조회한다.
+     */
+    get: operations['getTimeline'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/drive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/capacity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 팀 용량 정보 조회
-         * @description 팀 용량 정보를 조회한다.
-         */
-        get: operations["getCapacityInfo"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 드라이브 조회
+     * @description 드라이브 뷰를 조회한다.
+     */
+    get: operations['getDrive'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/capacity': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/category": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 카테고리 조회
-         * @description 카테고리 리스트를 조회한다.
-         */
-        get: operations["getCategories"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 팀 용량 정보 조회
+     * @description 팀 용량 정보를 조회한다.
+     */
+    get: operations['getCapacityInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/category': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/position": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getMemberTeamInform"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 카테고리 조회
+     * @description 카테고리 리스트를 조회한다.
+     */
+    get: operations['getCategories'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/position': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/{teamId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 노트 목록 조회
-         * @description 특정 팀의 노트 목록을 조회한다.
-         */
-        get: operations["getNote"];
-        put?: never;
-        post?: never;
-        /**
-         * 노트 삭제
-         * @description 특정 팀의 노트를 삭제한다.
-         */
-        delete: operations["deleteNotes"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getMemberTeamInform'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/{teamId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/notes/{teamId}/{noteId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 노트 상세 조회
-         * @description 특정 노트의 상세 정보를 조회한다.
-         */
-        get: operations["getNoteDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 노트 목록 조회
+     * @description 특정 팀의 노트 목록을 조회한다.
+     */
+    get: operations['getNote'];
+    put?: never;
+    post?: never;
+    /**
+     * 노트 삭제
+     * @description 특정 팀의 노트를 삭제한다.
+     */
+    delete: operations['deleteNotes'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/notes/{teamId}/{noteId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/members/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 소속 팀 가져오기
-         * @description 왼쪽 사이드바의 소속된 팀 정보를 가져옵니다.
-         */
-        get: operations["getBelongTeam"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 노트 상세 조회
+     * @description 특정 노트의 상세 정보를 조회한다.
+     */
+    get: operations['getNoteDetail'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/members/teams': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/file/upload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Presigned Url 생성
-         * @description s3로부터 Presigned Url을 생성한다.
-         */
-        get: operations["getPreSignedUrl"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 소속 팀 가져오기
+     * @description 왼쪽 사이드바의 소속된 팀 정보를 가져옵니다.
+     */
+    get: operations['getBelongTeam'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/file/upload': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/documents/team/{teamId}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 전체 문서 조회
-         * @description 전체 문서를 조회한다.
-         */
-        get: operations["getAllDocuments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Presigned Url 생성
+     * @description s3로부터 Presigned Url을 생성한다.
+     */
+    get: operations['getPreSignedUrl'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/documents/team/{teamId}/timeline': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/auth/reissue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 엑세스 토큰 재발급
-         * @description 엑세스 토큰 재발급 메서드입니다.
-         */
-        get: operations["reissue"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 전체 문서 조회
+     * @description 전체 문서를 조회한다.
+     */
+    get: operations['getAllDocuments'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/auth/reissue': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * 팀 삭제
-         * @description 팀을 삭제한다.
-         */
-        delete: operations["deleteTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * 엑세스 토큰 재발급
+     * @description 엑세스 토큰 재발급 메서드입니다.
+     */
+    get: operations['reissue'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/teams/{teamId}/time-block/{timeBlockId}/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * 타임 블록 파일 태그 삭제
-         * @description 타임 블록의 파일 태그를 삭제한다.
-         */
-        delete: operations["deleteDocumentTag"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * 팀 삭제
+     * @description 팀을 삭제한다.
+     */
+    delete: operations['deleteTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/teams/{teamId}/time-block/{timeBlockId}/tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/members/{kickOutMemberId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete: operations["kickOutMemberFromTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * 타임 블록 파일 태그 삭제
+     * @description 타임 블록의 파일 태그를 삭제한다.
+     */
+    delete: operations['deleteDocumentTag'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/members/{kickOutMemberId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/team-member/teams/{teamId}/leave": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete: operations["leaveTeam"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: operations['kickOutMemberFromTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/team-member/teams/{teamId}/leave': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: operations['leaveTeam'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        ErrorResponse: {
-            success?: boolean;
-            message: string;
-        };
-        TeamCreateRequest: {
-            name: string;
-            /** @enum {string} */
-            category: "전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹";
-            iconImageUrl: string;
-        };
-        SuccessResponseTeamCreateResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TeamCreateResponse"];
-        };
-        TeamCreateResponse: {
-            /** Format: int64 */
-            teamId: number;
-        };
-        TimeBlockCreateRequest: {
-            name: string;
-            color: string;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            /** @enum {string} */
-            blockType: "MEETING" | "RECRUITING" | "STUDY" | "EVENT" | "NOTICE" | "ETC";
-            documentIds: number[];
-        };
-        SuccessResponseTimeBlockCreateResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TimeBlockCreateResponse"];
-        };
-        TimeBlockCreateResponse: {
-            /** Format: int64 */
-            timeBlockId: number;
-        };
-        SuccessResponseObject: {
-            success?: boolean;
-            message: string;
-            data?: Record<string, never>;
-        };
-        FolderCreateRequest: {
-            /**
-             * @description 폴더 이름
-             * @example 폴더 1
-             */
-            name: string;
-        };
-        FolderCreateResponse: {
-            /** Format: int64 */
-            folderId: number;
-        };
-        SuccessResponseFolderCreateResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["FolderCreateResponse"];
-        };
-        DocumentCreateRequest: {
-            /**
-             * @description 파일 이름
-             * @example tiki.jpg
-             */
-            fileName: string;
-            /**
-             * @description 파일 url
-             * @example https://.../tiki.jpg
-             */
-            fileUrl: string;
-            /**
-             * @description 파일 key
-             * @example ....jpg
-             */
-            fileKey: string;
-            /**
-             * Format: double
-             * @description 파일 용량
-             * @example 1.23
-             */
-            capacity: number;
-        };
-        DocumentsCreateRequest: {
-            documents: components["schemas"]["DocumentCreateRequest"][];
-        };
-        NoteTemplateCreateRequest: {
-            title: string;
-            complete: boolean;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            answerWhatActivity: string;
-            answerHowToPrepare: string;
-            answerWhatIsDisappointedThing: string;
-            answerHowToFix: string;
-            timeBlockIds: number[];
-            documentIds: number[];
-            /** Format: int64 */
-            teamId: number;
-        };
-        NoteCreateServiceResponse: {
-            /** Format: int64 */
-            noteId?: number;
-        };
-        SuccessResponseNoteCreateServiceResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["NoteCreateServiceResponse"];
-        };
-        NoteFreeCreateRequest: {
-            title: string;
-            complete: boolean;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            contents: string;
-            timeBlockIds: number[];
-            documentIds: number[];
-            /** Format: int64 */
-            teamId: number;
-        };
-        MemberProfileCreateRequest: {
-            name: string;
-            /** Format: date */
-            birth: string;
-            /** @enum {string} */
-            univ: "건국대학교";
-            email: string;
-            password: string;
-            passwordChecker: string;
-        };
-        BaseResponse: Record<string, never>;
-        S3DeleteRequest: {
-            fileKey: string;
-        };
-        EmailRequest: {
-            email: string;
-        };
-        CodeVerificationRequest: {
-            email: string;
-            code: string;
-        };
-        SignInRequest: {
-            email: string;
-            password: string;
-        };
-        SignInGetResponse: {
-            accessToken: string;
-            refreshToken: string;
-        };
-        SuccessResponseSignInGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["SignInGetResponse"];
-        };
-        TeamMemberAndTeamInformUpdateRequest: {
-            teamMemberName: string;
-            teamName: string;
-            teamUrl: string;
-        };
-        FolderNameUpdateRequest: {
-            /**
-             * @description 수정할 폴더 이름
-             * @example 수정할 폴더 1
-             */
-            name: string;
-        };
-        UpdateTeamMemberNameRequest: {
-            newName: string;
-        };
-        NoteTemplateUpdateRequest: {
-            title: string;
-            complete: boolean;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            answerWhatActivity: string;
-            answerHowToPrepare: string;
-            answerWhatIsDisappointedThing: string;
-            answerHowToFix: string;
-            timeBlockIds: number[];
-            documentIds: number[];
-            /** Format: int64 */
-            teamId: number;
-        };
-        NoteFreeUpdateRequest: {
-            title: string;
-            complete: boolean;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            contents: string;
-            timeBlockIds: number[];
-            documentIds: number[];
-            /** Format: int64 */
-            teamId: number;
-        };
-        PasswordChangeRequest: {
-            email: string;
-            password: string;
-            passwordChecker: string;
-        };
-        SuccessResponseTeamsGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TeamsGetResponse"];
-        };
-        TeamGetResponse: {
-            /** Format: int64 */
-            teamId: number;
-            name: string;
-            /** @enum {string} */
-            category: "전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹";
-            /** @enum {string} */
-            univ: "건국대학교";
-            overview: string;
-            imageUrl: string;
-        };
-        TeamsGetResponse: {
-            teams: components["schemas"]["TeamGetResponse"][];
-        };
-        DeletedDocumentGetResponse: {
-            /** Format: int64 */
-            documentId: number;
-            name: string;
-            url: string;
-            /** Format: double */
-            capacity: number;
-        };
-        DeletedDocumentsGetResponse: {
-            deletedDocuments: components["schemas"]["DeletedDocumentGetResponse"][];
-        };
-        SuccessResponseDeletedDocumentsGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["DeletedDocumentsGetResponse"];
-        };
-        SuccessResponseTimelineGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TimelineGetResponse"];
-        };
-        TimeBlockGetResponse: {
-            /** Format: int64 */
-            timeBlockId: number;
-            name: string;
-            color: string;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            /** @enum {string} */
-            blockType: "MEETING" | "RECRUITING" | "STUDY" | "EVENT" | "NOTICE" | "ETC";
-        };
-        TimelineGetResponse: {
-            timeBlocks: components["schemas"]["TimeBlockGetResponse"][];
-        };
-        DocumentDetailGetResponse: {
-            /** Format: int64 */
-            documentId: number;
-            fileName: string;
-            fileUrl: string;
-            /** Format: int64 */
-            tagId: number;
-        };
-        NoteNameGetResponse: {
-            /** Format: int64 */
-            noteId: number;
-            noteName: string;
-        };
-        SuccessResponseTimeBlockDetailGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TimeBlockDetailGetResponse"];
-        };
-        TimeBlockDetailGetResponse: {
-            documents: components["schemas"]["DocumentDetailGetResponse"][];
-            notes: components["schemas"]["NoteNameGetResponse"][];
-        };
-        SuccessResponseTeamInformGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["TeamInformGetResponse"];
-        };
-        TeamInformGetResponse: {
-            teamName: string;
-            /** @enum {string} */
-            university: "건국대학교";
-            teamIconUrl: string;
-        };
-        FolderInfoGetResponse: {
-            /** Format: int64 */
-            id: number;
-            name: string;
-            /** Format: date-time */
-            createdTime: string;
-            path: string;
-        };
-        FoldersGetResponse: {
-            folders: components["schemas"]["FolderInfoGetResponse"][];
-        };
-        SuccessResponseFoldersGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["FoldersGetResponse"];
-        };
-        DocumentGetResponse: {
-            /** Format: int64 */
-            documentId: number;
-            name: string;
-            url: string;
-            /** Format: double */
-            capacity: number;
-            /** Format: date-time */
-            createdTime: string;
-            type: string;
-        };
-        DriveGetResponse: {
-            documents: components["schemas"]["DocumentGetResponse"][];
-            folders: components["schemas"]["FolderGetResponse"][];
-        };
-        FolderGetResponse: {
-            /** Format: int64 */
-            folderId: number;
-            name: string;
-            /** Format: date-time */
-            createdTime: string;
-            path: string;
-            type: string;
-        };
-        SuccessResponseDriveGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["DriveGetResponse"];
-        };
-        DocumentInfoGetResponse: {
-            /** Format: int64 */
-            documentId: number;
-            name: string;
-            url: string;
-            /** Format: double */
-            capacity: number;
-            /** Format: date-time */
-            createdTime: string;
-        };
-        DocumentsGetResponse: {
-            documents: components["schemas"]["DocumentInfoGetResponse"][];
-        };
-        SuccessResponseDocumentsGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["DocumentsGetResponse"];
-        };
-        SuccessResponseUsageGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["UsageGetResponse"];
-        };
-        UsageGetResponse: {
-            /** Format: double */
-            capacity: number;
-            /** Format: double */
-            usage: number;
-        };
-        CategoriesGetResponse: {
-            categories: ("전체" | "학술연구" | "문화예술" | "스포츠레저" | "사회활동" | "취미활동" | "창업비즈니스" | "과학기술" | "종교" | "국제교류" | "네트워킹")[];
-        };
-        SuccessResponseCategoriesGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["CategoriesGetResponse"];
-        };
-        MemberTeamInformGetResponse: {
-            /** @enum {string} */
-            position: "ADMIN" | "EXECUTIVE" | "MEMBER";
-            name: string;
-        };
-        SuccessResponseMemberTeamInformGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["MemberTeamInformGetResponse"];
-        };
-        NoteGetResponse: {
-            /** Format: int64 */
-            noteId: number;
-            title: string;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            author: string;
-            complete: boolean;
-            /** Format: date-time */
-            lastUpdatedAt: string;
-        };
-        NoteListGetServiceResponse: {
-            noteGetResponseList: components["schemas"]["NoteGetResponse"][];
-        };
-        SuccessResponseNoteListGetServiceResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["NoteListGetServiceResponse"];
-        };
-        DocumentTagGetServiceResponse: {
-            /** Format: int64 */
-            id?: number;
-            fileName?: string;
-            fileUrl?: string;
-            /** Format: double */
-            capacity?: number;
-        };
-        NoteFreeDetailGetServiceResponse: {
-            /** Format: int64 */
-            noteId: number;
-            /** @enum {string} */
-            noteType: "FREE" | "TEMPLATE";
-            title: string;
-            author: string;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            complete: boolean;
-            contents: string;
-            documentList: components["schemas"]["DocumentTagGetServiceResponse"][];
-            timeBlockList: components["schemas"]["TimeBlockTagServiceResponse"][];
-        };
-        TimeBlockTagServiceResponse: {
-            /** Format: int64 */
-            id?: number;
-            name?: string;
-            color?: string;
-        };
-        NoteTemplateDetailGetServiceResponse: {
-            /** Format: int64 */
-            noteId: number;
-            /** @enum {string} */
-            noteType: "FREE" | "TEMPLATE";
-            title: string;
-            author: string;
-            /** Format: date */
-            startDate: string;
-            /** Format: date */
-            endDate: string;
-            complete: boolean;
-            answerWhatActivity: string;
-            answerHowToPrepare: string;
-            answerWhatIsDisappointedThing: string;
-            answerHowToFix: string;
-            documentList: components["schemas"]["DocumentTagGetServiceResponse"][];
-            timeBlockList: components["schemas"]["TimeBlockTagServiceResponse"][];
-        };
-        BelongTeamGetResponse: {
-            /** Format: int64 */
-            id: number;
-            name: string;
-            iconImageUrl: string;
-        };
-        BelongTeamsGetResponse: {
-            belongTeamGetResponses: components["schemas"]["BelongTeamGetResponse"][];
-        };
-        SuccessResponseBelongTeamsGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["BelongTeamsGetResponse"];
-        };
-        PreSignedUrlResponse: {
-            fileName: string;
-            url: string;
-        };
-        SuccessResponsePreSignedUrlResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["PreSignedUrlResponse"];
-        };
-        SuccessResponse: {
-            success?: boolean;
-            message: string;
-            data?: Record<string, never>;
-        };
-        ReissueGetResponse: {
-            accessToken: string;
-        };
-        SuccessResponseReissueGetResponse: {
-            success?: boolean;
-            message: string;
-            data?: components["schemas"]["ReissueGetResponse"];
-        };
-        SuccessResponseVoid: {
-            success?: boolean;
-            message: string;
-            data?: Record<string, never>;
-        };
+  schemas: {
+    ErrorResponse: {
+      success?: boolean;
+      message: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    TeamCreateRequest: {
+      name: string;
+      /** @enum {string} */
+      category:
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹';
+      iconImageUrl: string;
+    };
+    SuccessResponseTeamCreateResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TeamCreateResponse'];
+    };
+    TeamCreateResponse: {
+      /** Format: int64 */
+      teamId: number;
+    };
+    TimeBlockCreateRequest: {
+      name: string;
+      color: string;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      /** @enum {string} */
+      blockType: 'MEETING' | 'RECRUITING' | 'STUDY' | 'EVENT' | 'NOTICE' | 'ETC';
+      documentIds: number[];
+    };
+    SuccessResponseTimeBlockCreateResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TimeBlockCreateResponse'];
+    };
+    TimeBlockCreateResponse: {
+      /** Format: int64 */
+      timeBlockId: number;
+    };
+    SuccessResponseObject: {
+      success?: boolean;
+      message: string;
+      data?: Record<string, never>;
+    };
+    FolderCreateRequest: {
+      /**
+       * @description 폴더 이름
+       * @example 폴더 1
+       */
+      name: string;
+    };
+    FolderCreateResponse: {
+      /** Format: int64 */
+      folderId: number;
+    };
+    SuccessResponseFolderCreateResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['FolderCreateResponse'];
+    };
+    DocumentCreateRequest: {
+      /**
+       * @description 파일 이름
+       * @example tiki.jpg
+       */
+      fileName: string;
+      /**
+       * @description 파일 url
+       * @example https://.../tiki.jpg
+       */
+      fileUrl: string;
+      /**
+       * @description 파일 key
+       * @example ....jpg
+       */
+      fileKey: string;
+      /**
+       * Format: double
+       * @description 파일 용량
+       * @example 1.23
+       */
+      capacity: number;
+    };
+    DocumentsCreateRequest: {
+      documents: components['schemas']['DocumentCreateRequest'][];
+    };
+    NoteTemplateCreateRequest: {
+      title: string;
+      complete: boolean;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      answerWhatActivity: string;
+      answerHowToPrepare: string;
+      answerWhatIsDisappointedThing: string;
+      answerHowToFix: string;
+      timeBlockIds: number[];
+      documentIds: number[];
+      /** Format: int64 */
+      teamId: number;
+    };
+    NoteCreateServiceResponse: {
+      /** Format: int64 */
+      noteId?: number;
+    };
+    SuccessResponseNoteCreateServiceResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['NoteCreateServiceResponse'];
+    };
+    NoteFreeCreateRequest: {
+      title: string;
+      complete: boolean;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      contents: string;
+      timeBlockIds: number[];
+      documentIds: number[];
+      /** Format: int64 */
+      teamId: number;
+    };
+    MemberProfileCreateRequest: {
+      name: string;
+      /** Format: date */
+      birth: string;
+      /** @enum {string} */
+      univ: '건국대학교';
+      email: string;
+      password: string;
+      passwordChecker: string;
+    };
+    BaseResponse: Record<string, never>;
+    S3DeleteRequest: {
+      fileKey: string;
+    };
+    EmailRequest: {
+      email: string;
+    };
+    CodeVerificationRequest: {
+      email: string;
+      code: string;
+    };
+    SignInRequest: {
+      email: string;
+      password: string;
+    };
+    SignInGetResponse: {
+      accessToken: string;
+      refreshToken: string;
+    };
+    SuccessResponseSignInGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['SignInGetResponse'];
+    };
+    TeamMemberAndTeamInformUpdateRequest: {
+      teamMemberName: string;
+      teamName: string;
+      teamUrl: string;
+    };
+    FolderNameUpdateRequest: {
+      /**
+       * @description 수정할 폴더 이름
+       * @example 수정할 폴더 1
+       */
+      name: string;
+    };
+    UpdateTeamMemberNameRequest: {
+      newName: string;
+    };
+    NoteTemplateUpdateRequest: {
+      title: string;
+      complete: boolean;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      answerWhatActivity: string;
+      answerHowToPrepare: string;
+      answerWhatIsDisappointedThing: string;
+      answerHowToFix: string;
+      timeBlockIds: number[];
+      documentIds: number[];
+      /** Format: int64 */
+      teamId: number;
+    };
+    NoteFreeUpdateRequest: {
+      title: string;
+      complete: boolean;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      contents: string;
+      timeBlockIds: number[];
+      documentIds: number[];
+      /** Format: int64 */
+      teamId: number;
+    };
+    PasswordChangeRequest: {
+      email: string;
+      password: string;
+      passwordChecker: string;
+    };
+    SuccessResponseTeamsGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TeamsGetResponse'];
+    };
+    TeamGetResponse: {
+      /** Format: int64 */
+      teamId: number;
+      name: string;
+      /** @enum {string} */
+      category:
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹';
+      /** @enum {string} */
+      univ: '건국대학교';
+      overview: string;
+      imageUrl: string;
+    };
+    TeamsGetResponse: {
+      teams: components['schemas']['TeamGetResponse'][];
+    };
+    DeletedDocumentGetResponse: {
+      /** Format: int64 */
+      documentId: number;
+      name: string;
+      url: string;
+      /** Format: double */
+      capacity: number;
+    };
+    DeletedDocumentsGetResponse: {
+      deletedDocuments: components['schemas']['DeletedDocumentGetResponse'][];
+    };
+    SuccessResponseDeletedDocumentsGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['DeletedDocumentsGetResponse'];
+    };
+    SuccessResponseTimelineGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TimelineGetResponse'];
+    };
+    TimeBlockGetResponse: {
+      /** Format: int64 */
+      timeBlockId: number;
+      name: string;
+      color: string;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      /** @enum {string} */
+      blockType: 'MEETING' | 'RECRUITING' | 'STUDY' | 'EVENT' | 'NOTICE' | 'ETC';
+    };
+    TimelineGetResponse: {
+      timeBlocks: components['schemas']['TimeBlockGetResponse'][];
+    };
+    DocumentDetailGetResponse: {
+      /** Format: int64 */
+      documentId: number;
+      fileName: string;
+      fileUrl: string;
+      /** Format: int64 */
+      tagId: number;
+    };
+    NoteNameGetResponse: {
+      /** Format: int64 */
+      noteId: number;
+      noteName: string;
+    };
+    SuccessResponseTimeBlockDetailGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TimeBlockDetailGetResponse'];
+    };
+    TimeBlockDetailGetResponse: {
+      documents: components['schemas']['DocumentDetailGetResponse'][];
+      notes: components['schemas']['NoteNameGetResponse'][];
+    };
+    SuccessResponseTeamInformGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['TeamInformGetResponse'];
+    };
+    TeamInformGetResponse: {
+      teamName: string;
+      /** @enum {string} */
+      university: '건국대학교';
+      teamIconUrl: string;
+    };
+    FolderInfoGetResponse: {
+      /** Format: int64 */
+      id: number;
+      name: string;
+      /** Format: date-time */
+      createdTime: string;
+      path: string;
+    };
+    FoldersGetResponse: {
+      folders: components['schemas']['FolderInfoGetResponse'][];
+    };
+    SuccessResponseFoldersGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['FoldersGetResponse'];
+    };
+    DocumentGetResponse: {
+      /** Format: int64 */
+      documentId: number;
+      name: string;
+      url: string;
+      /** Format: double */
+      capacity: number;
+      /** Format: date-time */
+      createdTime: string;
+      type: string;
+    };
+    DriveGetResponse: {
+      documents: components['schemas']['DocumentGetResponse'][];
+      folders: components['schemas']['FolderGetResponse'][];
+    };
+    FolderGetResponse: {
+      /** Format: int64 */
+      folderId: number;
+      name: string;
+      /** Format: date-time */
+      createdTime: string;
+      path: string;
+      type: string;
+    };
+    SuccessResponseDriveGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['DriveGetResponse'];
+    };
+    DocumentInfoGetResponse: {
+      /** Format: int64 */
+      documentId: number;
+      name: string;
+      url: string;
+      /** Format: double */
+      capacity: number;
+      /** Format: date-time */
+      createdTime: string;
+    };
+    DocumentsGetResponse: {
+      documents: components['schemas']['DocumentInfoGetResponse'][];
+    };
+    SuccessResponseDocumentsGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['DocumentsGetResponse'];
+    };
+    SuccessResponseUsageGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['UsageGetResponse'];
+    };
+    UsageGetResponse: {
+      /** Format: double */
+      capacity: number;
+      /** Format: double */
+      usage: number;
+    };
+    CategoriesGetResponse: {
+      categories: (
+        | '전체'
+        | '학술연구'
+        | '문화예술'
+        | '스포츠레저'
+        | '사회활동'
+        | '취미활동'
+        | '창업비즈니스'
+        | '과학기술'
+        | '종교'
+        | '국제교류'
+        | '네트워킹'
+      )[];
+    };
+    SuccessResponseCategoriesGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['CategoriesGetResponse'];
+    };
+    MemberTeamInformGetResponse: {
+      /** @enum {string} */
+      position: 'ADMIN' | 'EXECUTIVE' | 'MEMBER';
+      name: string;
+    };
+    SuccessResponseMemberTeamInformGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['MemberTeamInformGetResponse'];
+    };
+    NoteGetResponse: {
+      /** Format: int64 */
+      noteId: number;
+      title: string;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      author: string;
+      complete: boolean;
+      /** Format: date-time */
+      lastUpdatedAt: string;
+    };
+    NoteListGetServiceResponse: {
+      noteGetResponseList: components['schemas']['NoteGetResponse'][];
+    };
+    SuccessResponseNoteListGetServiceResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['NoteListGetServiceResponse'];
+    };
+    DocumentTagGetServiceResponse: {
+      /** Format: int64 */
+      id?: number;
+      fileName?: string;
+      fileUrl?: string;
+      /** Format: double */
+      capacity?: number;
+    };
+    NoteFreeDetailGetServiceResponse: {
+      /** Format: int64 */
+      noteId: number;
+      /** @enum {string} */
+      noteType: 'FREE' | 'TEMPLATE';
+      title: string;
+      author: string;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      complete: boolean;
+      contents: string;
+      documentList: components['schemas']['DocumentTagGetServiceResponse'][];
+      timeBlockList: components['schemas']['TimeBlockTagServiceResponse'][];
+    };
+    TimeBlockTagServiceResponse: {
+      /** Format: int64 */
+      id?: number;
+      name?: string;
+      color?: string;
+    };
+    NoteTemplateDetailGetServiceResponse: {
+      /** Format: int64 */
+      noteId: number;
+      /** @enum {string} */
+      noteType: 'FREE' | 'TEMPLATE';
+      title: string;
+      author: string;
+      /** Format: date */
+      startDate: string;
+      /** Format: date */
+      endDate: string;
+      complete: boolean;
+      answerWhatActivity: string;
+      answerHowToPrepare: string;
+      answerWhatIsDisappointedThing: string;
+      answerHowToFix: string;
+      documentList: components['schemas']['DocumentTagGetServiceResponse'][];
+      timeBlockList: components['schemas']['TimeBlockTagServiceResponse'][];
+    };
+    BelongTeamGetResponse: {
+      /** Format: int64 */
+      id: number;
+      name: string;
+      iconImageUrl: string;
+    };
+    BelongTeamsGetResponse: {
+      belongTeamGetResponses: components['schemas']['BelongTeamGetResponse'][];
+    };
+    SuccessResponseBelongTeamsGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['BelongTeamsGetResponse'];
+    };
+    PreSignedUrlResponse: {
+      fileName: string;
+      url: string;
+    };
+    SuccessResponsePreSignedUrlResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['PreSignedUrlResponse'];
+    };
+    SuccessResponse: {
+      success?: boolean;
+      message: string;
+      data?: Record<string, never>;
+    };
+    ReissueGetResponse: {
+      accessToken: string;
+    };
+    SuccessResponseReissueGetResponse: {
+      success?: boolean;
+      message: string;
+      data?: components['schemas']['ReissueGetResponse'];
+    };
+    SuccessResponseVoid: {
+      success?: boolean;
+      message: string;
+      data?: Record<string, never>;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getAllTeams: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTeamsGetResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  getAllTeams: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    createTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TeamCreateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTeamsGetResponse'];
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTeamCreateResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getTrash: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDeletedDocumentsGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    restore: {
-        parameters: {
-            query: {
-                /**
-                 * @description 복구할 파일 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TeamCreateRequest'];
+      };
     };
-    deleteTrash: {
-        parameters: {
-            query: {
-                /**
-                 * @description 삭제할 파일 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTeamCreateResponse'];
         };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    createTimeBlock: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TimeBlockCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimeBlockCreateResponse"];
-                };
-            };
-            /** @description 타입 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  getTrash: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getTimeBlockDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimeBlockDetailGetResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDeletedDocumentsGetResponse'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    createDocumentTag: {
-        parameters: {
-            query: {
-                /**
-                 * @description 추가할 파일 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  restore: {
+    parameters: {
+      query: {
+        /**
+         * @description 복구할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    deleteTimeBlock: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getFolders: {
-        parameters: {
-            query?: {
-                /**
-                 * @description 조회할 폴더 id (최상단은 비워두기)
-                 * @example 1
-                 */
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseFoldersGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteTrash: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    createFolder: {
-        parameters: {
-            query?: {
-                /**
-                 * @description 생성할 폴더가 속할 폴더 id (최상단은 비워두기)
-                 * @example 1
-                 */
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FolderCreateRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseFolderCreateResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    delete: {
-        parameters: {
-            query: {
-                /**
-                 * @description 삭제할 폴더 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                folderId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createTimeBlock: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getDocuments: {
-        parameters: {
-            query?: {
-                /**
-                 * @description 조회할 폴더 id (최상단은 비워두기)
-                 * @example 1
-                 */
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDocumentsGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TimeBlockCreateRequest'];
+      };
     };
-    createDocuments: {
-        parameters: {
-            query?: {
-                /**
-                 * @description 생성할 파일이 속할 폴더 id
-                 * @example 1
-                 */
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DocumentsCreateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimeBlockCreateResponse'];
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 타입 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    delete_1: {
-        parameters: {
-            query: {
-                /**
-                 * @description 삭제할 파일 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                documentId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": Record<string, never>;
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  getTimeBlockDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    createNoteTemplate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteTemplateCreateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimeBlockDetailGetResponse'];
         };
-        responses: {
-            /** @description 노트 생성 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteCreateServiceResponse"];
-                };
-            };
-            /** @description 요청 데이터 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    createNoteFree: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteFreeCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description 노트 생성 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteCreateServiceResponse"];
-                };
-            };
-            /** @description 요청 데이터 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createDocumentTag: {
+    parameters: {
+      query: {
+        /**
+         * @description 추가할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    signUp: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MemberProfileCreateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 비밀번호 불일치 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 이미 가입된 아이디 */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteFile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["S3DeleteRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description S3 버킷의 파일 삭제 실패 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteTimeBlock: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
     };
-    sendSignUpMail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 이미 가입된 아이디 */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 타임 블록 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    sendChangingPasswordMail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 가입되지 않은 이메일 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  getFolders: {
+    parameters: {
+      query?: {
+        /**
+         * @description 조회할 폴더 id (최상단은 비워두기)
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    checkCode: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CodeVerificationRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseFoldersGetResponse'];
         };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 이메일 형식 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 인증 값 불일치 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 인증 정보가 존재하지 않음 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    signIn: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SignInRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseSignInGetResponse"];
-                };
-            };
-            /** @description 일치하지 않은 비밀번호 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createFolder: {
+    parameters: {
+      query?: {
+        /**
+         * @description 생성할 폴더가 속할 폴더 id (최상단은 비워두기)
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    alterAdmin: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                targetId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FolderCreateRequest'];
+      };
     };
-    getTeamName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTeamInformGetResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseFolderCreateResponse'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateTeamAndTeamMemberInform: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TeamMemberAndTeamInformUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  delete: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 폴더 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        folderId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    updateFolderName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 수정할 폴더 id
-                 * @example 1
-                 */
-                folderId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FolderNameUpdateRequest"];
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateTeamMemberName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateTeamMemberNameRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  getDocuments: {
+    parameters: {
+      query?: {
+        /**
+         * @description 조회할 폴더 id (최상단은 비워두기)
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    updateNoteTemplate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 노트 id
-                 * @example 1
-                 */
-                noteId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteTemplateUpdateRequest"];
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDocumentsGetResponse'];
         };
-        responses: {
-            /** @description 노트 수정 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 요청 데이터 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 존재하지 않는 노트 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    updateNoteFree: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 노트 id
-                 * @example 1
-                 */
-                noteId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NoteFreeUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description 노트 수정 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 요청 데이터 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 존재하지 않는 노트 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createDocuments: {
+    parameters: {
+      query?: {
+        /**
+         * @description 생성할 파일이 속할 폴더 id
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    changePassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PasswordChangeRequest"];
-            };
-        };
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 비밀번호가 일치하지 않습니다. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DocumentsCreateRequest'];
+      };
     };
-    getTimeline: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-                /**
-                 * @description 조회할 타임라인의 년도와 월 정보
-                 * @example 2024-07
-                 */
-                date: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseTimelineGetResponse"];
-                };
-            };
-            /** @description 타입 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getDrive: {
-        parameters: {
-            query?: {
-                /**
-                 * @description 조회할 폴더 id (최상단은 비워두기)
-                 * @example 1
-                 */
-                folderId?: number;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDriveGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  delete_1: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        documentId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
     };
-    getCapacityInfo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseUsageGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': Record<string, never>;
         };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getCategories: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseCategoriesGetResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createNoteTemplate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getMemberTeamInform: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseMemberTeamInformGetResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteTemplateCreateRequest'];
+      };
     };
-    getNote: {
-        parameters: {
-            query: {
-                /**
-                 * @description 생성시간
-                 * @example yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn
-                 */
-                createdAt: string;
-                /**
-                 * @description 정렬 순서
-                 * @example ASC, DESC
-                 */
-                sortOrder: "ASC" | "DESC";
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 노트 생성 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 조회 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseNoteListGetServiceResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteCreateServiceResponse'];
         };
+      };
+      /** @description 요청 데이터 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteNotes: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 노트 id 리스트
-                 * @example [
-                 *       1,
-                 *       2,
-                 *       3,
-                 *       4,
-                 *       5
-                 *     ]
-                 */
-                noteIds: number[];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 삭제 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseVoid"];
-                };
-            };
-            /** @description 요청 데이터 오류 */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  createNoteFree: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getNoteDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 노트 id
-                 * @example 1
-                 */
-                noteId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 조회 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NoteFreeDetailGetServiceResponse"] | components["schemas"]["NoteTemplateDetailGetServiceResponse"];
-                };
-            };
-            /** @description 접근 권한 없음(토큰 에러) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteFreeCreateRequest'];
+      };
     };
-    getBelongTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description 노트 생성 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseBelongTeamsGetResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteCreateServiceResponse'];
         };
+      };
+      /** @description 요청 데이터 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    getPreSignedUrl: {
-        parameters: {
-            query: {
-                /**
-                 * @description 파일 형식
-                 * @example hwp, pdf, ...
-                 */
-                fileFormat: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponsePreSignedUrlResponse"];
-                };
-            };
-            /** @description S3 PRESIGNED URL 불러오기 실패 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  signUp: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getAllDocuments: {
-        parameters: {
-            query: {
-                /**
-                 * @description 타임라인 타입
-                 * @example executive, member
-                 */
-                type: string;
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseDocumentsGetResponse"];
-                };
-            };
-            /** @description 접근 권한 없음 */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 팀에 존재하지 않는 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberProfileCreateRequest'];
+      };
     };
-    reissue: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseReissueGetResponse"];
-                };
-            };
-            /** @description 유효하지 않은 키, 인증되지 않은 사용자 */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
         };
+      };
+      /** @description 비밀번호 불일치 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 이미 가입된 아이디 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    deleteTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-            /** @description 유효하지 않은 회원 */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+  };
+  deleteFile: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteDocumentTag: {
-        parameters: {
-            query: {
-                /**
-                 * @description 삭제할 파일 태그 id 리스트
-                 * @example [
-                 *       1,
-                 *       2
-                 *     ]
-                 */
-                tagId: number[];
-            };
-            header?: never;
-            path: {
-                /**
-                 * @description 팀 id
-                 * @example 1
-                 */
-                teamId: number;
-                /**
-                 * @description 타임 블록 id
-                 * @example 1
-                 */
-                timeBlockId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 성공 */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["SuccessResponseObject"];
-                };
-            };
-            /** @description 서버 내부 오류 */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description 클라이언트(요청) 오류 */
-            "4xx": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['S3DeleteRequest'];
+      };
     };
-    kickOutMemberFromTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-                kickOutMemberId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
         };
+      };
+      /** @description S3 버킷의 파일 삭제 실패 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
     };
-    leaveTeam: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                teamId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["BaseResponse"];
-                };
-            };
-        };
+  };
+  sendSignUpMail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 이미 가입된 아이디 */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  sendChangingPasswordMail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EmailRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 가입되지 않은 이메일 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  checkCode: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CodeVerificationRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 이메일 형식 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 인증 값 불일치 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 인증 정보가 존재하지 않음 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  signIn: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SignInRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseSignInGetResponse'];
+        };
+      };
+      /** @description 일치하지 않은 비밀번호 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  alterAdmin: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+        targetId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  getTeamName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTeamInformGetResponse'];
+        };
+      };
+    };
+  };
+  updateTeamAndTeamMemberInform: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TeamMemberAndTeamInformUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateFolderName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 수정할 폴더 id
+         * @example 1
+         */
+        folderId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FolderNameUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateTeamMemberName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateTeamMemberNameRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  updateNoteTemplate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 노트 id
+         * @example 1
+         */
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteTemplateUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description 노트 수정 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 요청 데이터 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 존재하지 않는 노트 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  updateNoteFree: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 노트 id
+         * @example 1
+         */
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['NoteFreeUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description 노트 수정 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 요청 데이터 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 존재하지 않는 노트 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  changePassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PasswordChangeRequest'];
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 비밀번호가 일치하지 않습니다. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getTimeline: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+        /**
+         * @description 조회할 타임라인의 년도와 월 정보
+         * @example 2024-07
+         */
+        date: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseTimelineGetResponse'];
+        };
+      };
+      /** @description 타입 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원, 유효하지 않은 팀 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getDrive: {
+    parameters: {
+      query?: {
+        /**
+         * @description 조회할 폴더 id (최상단은 비워두기)
+         * @example 1
+         */
+        folderId?: number;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDriveGetResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCapacityInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseUsageGetResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getCategories: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseCategoriesGetResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getMemberTeamInform: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseMemberTeamInformGetResponse'];
+        };
+      };
+    };
+  };
+  getNote: {
+    parameters: {
+      query: {
+        /**
+         * @description 생성시간
+         * @example yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn
+         */
+        createdAt: string;
+        /**
+         * @description 정렬 순서
+         * @example ASC, DESC
+         */
+        sortOrder: 'ASC' | 'DESC';
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 조회 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseNoteListGetServiceResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteNotes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 노트 id 리스트
+         * @example [
+         *       1,
+         *       2,
+         *       3,
+         *       4,
+         *       5
+         *     ]
+         */
+        noteIds: number[];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 삭제 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseVoid'];
+        };
+      };
+      /** @description 요청 데이터 오류 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getNoteDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 노트 id
+         * @example 1
+         */
+        noteId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 조회 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | components['schemas']['NoteFreeDetailGetServiceResponse']
+            | components['schemas']['NoteTemplateDetailGetServiceResponse'];
+        };
+      };
+      /** @description 접근 권한 없음(토큰 에러) */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getBelongTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseBelongTeamsGetResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getPreSignedUrl: {
+    parameters: {
+      query: {
+        /**
+         * @description 파일 형식
+         * @example hwp, pdf, ...
+         */
+        fileFormat: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponsePreSignedUrlResponse'];
+        };
+      };
+      /** @description S3 PRESIGNED URL 불러오기 실패 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  getAllDocuments: {
+    parameters: {
+      query: {
+        /**
+         * @description 타임라인 타입
+         * @example executive, member
+         */
+        type: string;
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseDocumentsGetResponse'];
+        };
+      };
+      /** @description 접근 권한 없음 */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 팀에 존재하지 않는 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  reissue: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseReissueGetResponse'];
+        };
+      };
+      /** @description 유효하지 않은 키, 인증되지 않은 사용자 */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+      /** @description 유효하지 않은 회원 */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  deleteDocumentTag: {
+    parameters: {
+      query: {
+        /**
+         * @description 삭제할 파일 태그 id 리스트
+         * @example [
+         *       1,
+         *       2
+         *     ]
+         */
+        tagId: number[];
+      };
+      header?: never;
+      path: {
+        /**
+         * @description 팀 id
+         * @example 1
+         */
+        teamId: number;
+        /**
+         * @description 타임 블록 id
+         * @example 1
+         */
+        timeBlockId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 성공 */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['SuccessResponseObject'];
+        };
+      };
+      /** @description 서버 내부 오류 */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description 클라이언트(요청) 오류 */
+      '4xx': {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  kickOutMemberFromTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+        kickOutMemberId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
+  leaveTeam: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        teamId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponse'];
+        };
+      };
+    };
+  };
 }

--- a/apps/client/src/shared/api/file/upload/index.ts
+++ b/apps/client/src/shared/api/file/upload/index.ts
@@ -1,10 +1,13 @@
-import { axiosInstance } from '@/shared/api/instance';
+import { client } from '@/shared/api/client';
 
-export const getFile = async (fileFormat: string) => {
-  const response = await axiosInstance.get('/file/upload', {
+export const getPresignedUrl = async (fileFormat: string) => {
+  const response = await client.GET('/api/v1/file/upload', {
     params: {
-      fileFormat: fileFormat,
+      query: {
+        fileFormat,
+      },
     },
   });
-  return response.data.data;
+
+  return response.data?.data;
 };

--- a/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
@@ -2,17 +2,17 @@ import { IcFolderLarge, IcThreeDots } from '@tiki/icon';
 import { CheckBox, Flex, Heading, MenuItem, MenuList, MenuRoot, theme } from '@tiki/ui';
 import { useOverlay } from '@tiki/utils';
 
+import { FolderItem } from '@/page/drive/type';
+
 import { OPTION_ICON } from '@/shared/component/FileGrid/icon';
 import { cardStyle, iconWrapperStyle, nameStyle, optionTextStyle } from '@/shared/component/FileGrid/index.style';
 
-type FolderGridProps = {
+type FolderGridProps = FolderItem & {
   variant?: 'primary' | 'secondary';
-  name: string;
-  path: string;
-  createdTime: string;
   isSelectable?: boolean;
   onSelect?: () => void;
   isSelected?: boolean;
+  onFolderClick?: () => void;
   /**
    * TODO
    * onChangeName
@@ -21,11 +21,23 @@ type FolderGridProps = {
    */
 };
 
-const FolderGrid = ({ name, variant = 'primary', isSelectable, isSelected = false, onSelect }: FolderGridProps) => {
+const FolderGrid = ({
+  name,
+  variant = 'primary',
+  isSelectable,
+  isSelected = false,
+  onSelect,
+  onFolderClick,
+}: FolderGridProps) => {
   const { isOpen, close, toggle } = useOverlay();
 
   return (
-    <article css={cardStyle(variant !== 'primary')}>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onFolderClick}
+      onKeyDown={(e) => e.key === 'Enter' && onFolderClick?.()}
+      css={cardStyle(variant !== 'primary')}>
       {isSelectable && (
         <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
       )}
@@ -55,7 +67,7 @@ const FolderGrid = ({ name, variant = 'primary', isSelectable, isSelected = fals
           </MenuRoot>
         )}
       </Flex>
-    </article>
+    </div>
   );
 };
 

--- a/apps/client/src/shared/hook/api/useGetFileQuery.ts
+++ b/apps/client/src/shared/hook/api/useGetFileQuery.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getFile } from '@/shared/api/file/upload';
+import { getPresignedUrl } from '@/shared/api/file/upload';
 import { extractFileExtension } from '@/shared/util/file';
 
 const useGetFileQuery = (file?: File) => {
   const fileExtension = file ? extractFileExtension(file.name) : '';
   return useQuery({
     queryKey: file ? ['fileFormat', file.name, fileExtension] : [],
-    queryFn: () => getFile(fileExtension),
+    queryFn: () => getPresignedUrl(fileExtension),
     enabled: !!file,
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-router-dom:
         specifier: ^6.24.1
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-query-params:
+        specifier: ^2.2.1
+        version: 2.2.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^1.6.1
@@ -3794,6 +3797,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-query-params@2.0.2:
+    resolution: {integrity: sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4200,6 +4206,19 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-query-params@2.2.1:
+    resolution: {integrity: sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==}
+    peerDependencies:
+      '@reach/router': ^1.2.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-router-dom: '>=5'
+    peerDependenciesMeta:
+      '@reach/router':
+        optional: true
+      react-router-dom:
+        optional: true
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -8074,6 +8093,8 @@ snapshots:
 
   semver@7.6.3: {}
 
+  serialize-query-params@2.0.2: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -8528,6 +8549,14 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      serialize-query-params: 2.0.2
+    optionalDependencies:
+      react-router-dom: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   util@0.12.5:
     dependencies:


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #351 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

### 주용 부분

파일 추가 API 연결하였습니다. `drive` 페이지에서 `changeFile` 핸들러 구현 시에 여러 파일을 받을 수 있도록 한 후 이를 모두 `presignedUrl`로 변환하여 `mutate`를 수행하는 과정을 거쳤습니다.

그리고 폴더를 클릭할 때에는 뷰는 동일하되 해당 드라이브 페이지에서 해당 폴더 안에 있는 파일들을 보여주어야 하는 요구사항이 있었습니다. 이를 `url params`로 구현하기 위해 `use-query-params` 라이브러리를 도입하였습니다. 이는 `url`의 파라미터 값을 상태로서 쉽게 사용할 수 있도록 해주는 라이브러리입니다. 즉 특정 폴더를 클릭하였을 때 해당 상태 setter를 호출하여 `url`의 `query param`을 변경하여 해당 폴더 안으로 이동하는 식으로 구현하였어요 !
드라이브 페이지에서 만약 `folderId`라는 `param` 값이 존재한다면 `api` 호출 시에도 해당 아이디를 보내 해당 폴더 안의 파일/폴더를 설정할 수 있게 됩니다.

