### PR TITLE
[Fix] QA 배포본 로그인 에러 해결

### DIFF
--- a/apps/client/src/page/dashboard/component/File/FileSection.tsx
+++ b/apps/client/src/page/dashboard/component/File/FileSection.tsx
@@ -15,6 +15,7 @@ import { extractFileExtension } from '@/shared/util/file';
 
 const FileSection = () => {
   const teamId = useInitializeTeamId();
+
   const { data: fileData } = $api.useQuery('get', '/api/v1/teams/{teamId}/drive', {
     params: {
       path: {

--- a/apps/client/src/page/dashboard/component/Handover/HandoverSection.style.ts
+++ b/apps/client/src/page/dashboard/component/Handover/HandoverSection.style.ts
@@ -5,8 +5,6 @@ import { dashboradScrollStyle } from '@/page/dashboard/DashboardPage.style';
 
 export const listItemStyle = css(
   {
-    flexDirection: 'column',
-    gap: '0.8rem',
     height: '100%',
 
     overflowY: 'scroll',

--- a/apps/client/src/page/dashboard/component/Handover/HandoverSection.tsx
+++ b/apps/client/src/page/dashboard/component/Handover/HandoverSection.tsx
@@ -10,13 +10,13 @@ import { useCurrentDate } from '@/shared/hook/common/useCurrentDate';
 
 const HandoverSection = () => {
   const createdAt = useCurrentDate();
-  const { data, isFetching } = useNoteData(createdAt);
+  const { data, isPending } = useNoteData(createdAt);
 
   return (
-    <Flex css={listItemStyle}>
+    <Flex styles={{ direction: 'column', gap: '0.8rem', align: 'center' }} css={listItemStyle}>
       {!data?.data?.noteGetResponseList[0] && <ItemAdder path={PATH.HANDOVER} />}
 
-      {isFetching ? (
+      {isPending ? (
         <Spinner size={30} />
       ) : (
         data?.data?.noteGetResponseList.map((note) => {

--- a/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/Timeline/Timeline.tsx
@@ -10,12 +10,9 @@ import { timelineContentStyle } from '@/page/dashboard/component/Timeline/Timeli
 
 import { $api } from '@/shared/api/client';
 import { PATH } from '@/shared/constant/path';
-import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 
-const Timeline = () => {
+const Timeline = ({ teamId }: { teamId: number }) => {
   const navigate = useNavigate();
-
-  const teamId = useInitializeTeamId();
 
   const { currentYear, currentMonth, endDay } = useDateContext();
 

--- a/apps/client/src/page/dashboard/component/Timeline/index.tsx
+++ b/apps/client/src/page/dashboard/component/Timeline/index.tsx
@@ -13,7 +13,7 @@ const TimelineSection = () => {
     <DateProvider teamId={teamId}>
       <TimeLineHeader />
       <Suspense>
-        <Timeline />
+        <Timeline teamId={teamId} />
       </Suspense>
     </DateProvider>
   );

--- a/apps/client/src/page/drive/hook/api/queries.ts
+++ b/apps/client/src/page/drive/hook/api/queries.ts
@@ -1,8 +1,8 @@
 import { $api } from '@/shared/api/client';
-import { useTeamId } from '@/shared/store/team';
+import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 
 export const useDriveData = () => {
-  const teamId = useTeamId();
+  const teamId = useInitializeTeamId();
 
   return $api.useSuspenseQuery('get', '/api/v1/teams/{teamId}/drive', {
     params: {

--- a/apps/client/src/page/login/index/hook/useLoginMutation.ts
+++ b/apps/client/src/page/login/index/hook/useLoginMutation.ts
@@ -26,7 +26,11 @@ export const useLoginMutation = () => {
 
       axiosInstance.defaults.headers.Authorization = `Bearer ${accessToken}`;
 
-      navigate(PATH.DASHBOARD);
+      const isExistingUser = !!localStorage.getItem('teamId');
+
+      isExistingUser
+        ? navigate(`${PATH.DASHBOARD}?teamId=${localStorage.getItem('teamId')}`)
+        : navigate(PATH.ONBOARDING);
     },
 
     onError: (error: AxiosError) => {

--- a/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
+++ b/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
@@ -9,25 +9,28 @@ import Item from '@/shared/component/SideNavBar/Item/Item';
 import { containerStyle, settingStyle, tikiLogoStyle } from '@/shared/component/SideNavBar/SideNavBar.style';
 import { PATH } from '@/shared/constant/path';
 import { useOpenModal } from '@/shared/store/modal';
+import { useTeamId, useTeamIdAction } from '@/shared/store/team';
 import { Team } from '@/shared/type/team';
 
 const SideNavBar = () => {
-  const [selectedId, setSelectedId] = useState('showcase');
+  const [isInShowcase, setIsInShowcase] = useState(false);
 
+  const teamId = useTeamId();
+  const { setTeamId } = useTeamIdAction();
   const navigate = useNavigate();
-
   const openModal = useOpenModal();
 
-  const { data } = $api.useQuery('get', '/api/v1/members/teams', {});
+  const { data } = $api.useQuery('get', '/api/v1/members/teams');
 
   const handleItemClick = (id: string, path: string) => {
-    setSelectedId(id);
-
     if (id === 'showcase') {
+      setTeamId(null);
+      setIsInShowcase(true);
       navigate(path);
     } else {
-      navigate(path);
+      setTeamId(+id);
       localStorage.setItem('teamId', id);
+      navigate(path);
     }
     close();
   };
@@ -42,7 +45,7 @@ const SideNavBar = () => {
       <Flex tag="ul" styles={{ direction: 'column', align: 'center' }}>
         <Item
           variant={{ type: 'dashboard', hoverMessage: 'showcase' }}
-          isClicked={selectedId === 'showcase'}
+          isClicked={isInShowcase}
           onLogoClick={() => handleItemClick('showcase', PATH.SHOWCASE)}
         />
         <Divider type="horizontal" size={56.78} color={theme.colors.gray_300} />
@@ -50,7 +53,7 @@ const SideNavBar = () => {
           return (
             <Item
               key={data.id}
-              isClicked={selectedId === String(data.id)}
+              isClicked={teamId === data.id}
               variant={{ type: 'team', logoUrl: data.iconImageUrl, hoverMessage: data.name }}
               onLogoClick={() => handleItemClick(String(data.id), `${PATH.DASHBOARD}?teamId=${data.id}`)}
             />

--- a/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
+++ b/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
@@ -1,11 +1,18 @@
-// type TeamResponse = paths['/api/v1/teams']['get']['responses']['200']['content']['*/*'];
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { paths } from '@/shared/__generated__/schema';
+import { $api } from '@/shared/api/client';
+import { PATH } from '@/shared/constant/path';
+import { useTeamIdAction } from '@/shared/store/team';
+
+type TeamResponse = paths['/api/v1/teams']['get']['responses']['200']['content']['*/*'];
 
 export const useInitializeTeamId = () => {
-  /**
-   * const { setTeamId } = useTeamIdAction();
+  const { setTeamId } = useTeamIdAction();
   const navigate = useNavigate();
 
-  const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams', {
+  const { data, isSuccess } = $api.useSuspenseQuery('get', '/api/v1/members/teams', {
     select: (response: TeamResponse) => {
       return response.data;
     },
@@ -26,7 +33,6 @@ export const useInitializeTeamId = () => {
       navigate(PATH.LOGIN);
     }
   });
-   */
 
   return Number(localStorage.getItem('teamId'));
 };

--- a/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
+++ b/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
@@ -1,15 +1,8 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-
-import { paths } from '@/shared/__generated__/schema';
-import { $api } from '@/shared/api/client';
-import { PATH } from '@/shared/constant/path';
-import { useTeamIdAction } from '@/shared/store/team';
-
-type TeamResponse = paths['/api/v1/teams']['get']['responses']['200']['content']['*/*'];
+// type TeamResponse = paths['/api/v1/teams']['get']['responses']['200']['content']['*/*'];
 
 export const useInitializeTeamId = () => {
-  const { setTeamId } = useTeamIdAction();
+  /**
+   * const { setTeamId } = useTeamIdAction();
   const navigate = useNavigate();
 
   const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams', {
@@ -33,6 +26,7 @@ export const useInitializeTeamId = () => {
       navigate(PATH.LOGIN);
     }
   });
+   */
 
   return Number(localStorage.getItem('teamId'));
 };

--- a/apps/client/src/shared/store/team.ts
+++ b/apps/client/src/shared/store/team.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
 
 type TeamStore = {
-  teamId: number;
+  teamId: number | null;
   actions: {
-    setTeamId: (id: number) => void;
+    setTeamId: (id: number | null) => void;
   };
 };
 
@@ -11,7 +11,7 @@ const useTeamStore = create<TeamStore>((set) => ({
   teamId: Number(localStorage.getItem('teamId')),
 
   actions: {
-    setTeamId: (teamId: number) =>
+    setTeamId: (teamId: number | null) =>
       set({
         teamId,
       }),


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #431 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

배포사이트에서 계속 로그인이 안되는 에러가 발생하였어요. 분석해보니 `useInitiallizeTeamId` 훅을 사용하고 있는데, 해당 훅에서의 `members/team` API가 `cancel` 되는 현상이 발생했습니다.

이유를 알아보니 `useQuery`를 사용하고 있는 해당 훅에서, 해당 쿼리의 상태가 `success`되고 `data`에 `defined`된 값이 들어오기 전에 해당 컴포넌트를 `navigate`를 통해 언마운트시키기 때문이였어요. 즉 데이터 패칭이 완전히 성공적으로 완료되기 전에 해당 컴포넌트를 언마운트해서 발생하였습니다.

로그인 페이지로 계속하여 리다이렉트 되는 이유는 쿼리의 `status`가 `success`가 되기전에 `useEffect`가 실행되므로 로그인 페이지로 리다이렉션 시키는 것 같습니다.

따라서 `useSuspenseQuery`로 변경하여 해결해주었습니다. 즉 해당 훅을 `suspense` 상태로 만들고 데이터 패칭이 완료되었을 때 해당 훅의 나머지 코드들을 실행시키도록 하였습니다. 이렇게 하니 `status`에는 항상 `success`필드가 들어오게 되고 정상적으로 리다이렉션이 수행되는 것을 확인하였습니다.

---

## 📌스크린샷 (선택)

https://github.com/user-attachments/assets/3ad2c448-36df-4456-809c-d803faa6c2c4

