### PR TITLE
[Feat] 헤더 미반영사항 기능 구현

### DIFF
--- a/apps/client/src/page/dashboard/DashboardPage.tsx
+++ b/apps/client/src/page/dashboard/DashboardPage.tsx
@@ -9,7 +9,7 @@ import HandoverSection from '@/page/dashboard/component/Handover/HandoverSection
 import TimelineSection from '@/page/dashboard/component/Timeline';
 
 import ContentBox from '@/shared/component/ContentBox/ContentBox';
-import { INVITATION_ID, INVITE_TEAM_ID } from '@/shared/constant/api';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 const DashboardPage = () => {
@@ -20,8 +20,8 @@ const DashboardPage = () => {
   };
 
   useEffect(() => {
-    if (localStorage.getItem(INVITATION_ID)) {
-      navigate(`${PATH.INVITE}/${localStorage.getItem(INVITE_TEAM_ID)}`);
+    if (localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+      navigate(`${PATH.INVITE}/${localStorage.getItem(STORAGE_KEY.INVITE_TEAM_ID)}`);
     }
   });
 

--- a/apps/client/src/page/handoverNote/component/CreateNote/NoteDetail/CreateNoteDetail.tsx
+++ b/apps/client/src/page/handoverNote/component/CreateNote/NoteDetail/CreateNoteDetail.tsx
@@ -17,6 +17,7 @@ import { formatDateToString } from '@/page/signUp/info/util/date';
 
 import { $api } from '@/shared/api/client';
 import { ActivityTag } from '@/shared/component/ActivityTagModal/ActivityTagModal';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 import { useOpenModal } from '@/shared/store/modal';
 
@@ -30,7 +31,7 @@ const CreateNoteDetail = ({ detail, setDetail }: NoteDetailProp) => {
   const [endDate, setEndDate] = useState<Date | null>(new Date());
 
   const teamId = useInitializeTeamId();
-  const accessToken = localStorage.getItem('ACCESS_TOKEN_KEY');
+  const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
   const { data: memberData } = $api.useQuery('get', '/api/v1/team-member/teams/{teamId}/members/position', {
     params: {

--- a/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
+++ b/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
@@ -2,14 +2,14 @@ import { useSearchParams } from 'react-router-dom';
 
 import { useGetInvitationInfo } from '@/page/invite/hook/queries';
 
-import { INVITATION_ID, INVITE_TEAM_ID } from '@/shared/constant/api';
+import { STORAGE_KEY } from '@/shared/constant/api';
 
 export const useInvitationInfo = () => {
   const [searchParams] = useSearchParams();
-  const invitationId = searchParams.get('invitationId') || localStorage.getItem(INVITATION_ID) || '';
-  const inviteTeamId = searchParams.get('teamId') || localStorage.getItem(INVITE_TEAM_ID) || '';
-  localStorage.setItem(INVITATION_ID, invitationId);
-  localStorage.setItem(INVITE_TEAM_ID, inviteTeamId);
+  const invitationId = searchParams.get('invitationId') || localStorage.getItem(STORAGE_KEY.INVITATION_ID) || '';
+  const inviteTeamId = searchParams.get('teamId') || localStorage.getItem(STORAGE_KEY.INVITE_TEAM_ID) || '';
+  localStorage.setItem(STORAGE_KEY.INVITATION_ID, invitationId);
+  localStorage.setItem(STORAGE_KEY.INVITE_TEAM_ID, inviteTeamId);
 
   const { data } = useGetInvitationInfo(+invitationId);
 

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -10,11 +10,11 @@ import { firstSpellStyle, inviteStyle } from '@/page/invite/index.styles';
 import { InvitationType } from '@/page/invite/type';
 
 import { components } from '@/shared/__generated__/schema';
-import { ACCESS_TOKEN_KEY, INVITATION_ID, INVITE_TEAM_ID } from '@/shared/constant/api';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 const InvitedPage = () => {
-  const isLogined = !!localStorage.getItem(ACCESS_TOKEN_KEY);
+  const isLogined = !!localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
   const { createToast } = useToastAction();
 
@@ -38,8 +38,8 @@ const InvitedPage = () => {
   }, [createToast, data, invitationInfo?.teamId, isLogined, navigate]);
 
   const deleteLocalStorageInviteInfo = () => {
-    localStorage.removeItem(INVITATION_ID);
-    localStorage.removeItem(INVITE_TEAM_ID);
+    localStorage.removeItem(STORAGE_KEY.INVITATION_ID);
+    localStorage.removeItem(STORAGE_KEY.INVITE_TEAM_ID);
   };
 
   const handleApproveInvitation = () => {
@@ -55,7 +55,7 @@ const InvitedPage = () => {
       {
         onSuccess: () => {
           deleteLocalStorageInviteInfo();
-          localStorage.setItem('teamId', `${teamId}`);
+          localStorage.setItem(STORAGE_KEY.TEAM_ID, `${teamId}`);
           navigate(PATH.DASHBOARD);
         },
         onError: (error: components['schemas']['ErrorResponse']) => {

--- a/apps/client/src/page/landing/LandingPage.tsx
+++ b/apps/client/src/page/landing/LandingPage.tsx
@@ -21,7 +21,7 @@ import Indicator from '@/page/landing/component/Indicator/Indicator';
 import LandingOverview from '@/page/landing/component/Overview/Overview';
 import { TEXT } from '@/page/landing/constant';
 
-import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 const LandingPage = () => {
@@ -53,7 +53,7 @@ const LandingPage = () => {
   };
 
   const 다음페이지로 = () => {
-    const isAuth = !!localStorage.getItem(ACCESS_TOKEN_KEY);
+    const isAuth = !!localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
     window.location.href = isAuth ? PATH.DASHBOARD : PATH.LOGIN;
   };

--- a/apps/client/src/page/login/index/hook/useLoginMutation.ts
+++ b/apps/client/src/page/login/index/hook/useLoginMutation.ts
@@ -10,7 +10,7 @@ import { ERROR_MESSAGE } from '@/page/login/index/constant';
 
 import { postSignIn } from '@/shared/api/auth/signin';
 import { axiosInstance } from '@/shared/api/instance';
-import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@/shared/constant/api';
+import { HTTP_STATUS_CODE, STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 export const useLoginMutation = () => {
@@ -22,14 +22,14 @@ export const useLoginMutation = () => {
     mutationFn: postSignIn,
 
     onSuccess: ({ data: { accessToken } }) => {
-      localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+      localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN_KEY, accessToken);
 
       axiosInstance.defaults.headers.Authorization = `Bearer ${accessToken}`;
 
-      const isExistingUser = !!localStorage.getItem('teamId');
+      const isExistingUser = !!localStorage.getItem(STORAGE_KEY.TEAM_ID);
 
       isExistingUser
-        ? navigate(`${PATH.DASHBOARD}?teamId=${localStorage.getItem('teamId')}`)
+        ? navigate(`${PATH.DASHBOARD}?teamId=${localStorage.getItem(STORAGE_KEY.TEAM_ID)}`)
         : navigate(PATH.ONBOARDING);
     },
 

--- a/apps/client/src/page/workspaceSetting/index.tsx
+++ b/apps/client/src/page/workspaceSetting/index.tsx
@@ -18,6 +18,7 @@ import {
 import { MemberType } from '@/page/workspaceSetting/type';
 
 import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 import { useCloseModal, useOpenModal } from '@/shared/store/modal';
@@ -89,7 +90,7 @@ const WorkspaceSettingPage = () => {
 
             closeModal();
 
-            localStorage.removeItem('teamId');
+            localStorage.removeItem(STORAGE_KEY.TEAM_ID);
 
             navigate(PATH.DASHBOARD);
             window.location.reload();

--- a/apps/client/src/shared/api/interceptor.ts
+++ b/apps/client/src/shared/api/interceptor.ts
@@ -5,7 +5,7 @@ import { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { HTTPError } from '@/shared/api/HTTPError';
 import { getReissuedToken } from '@/shared/api/auth/reissue';
 import { axiosInstance } from '@/shared/api/instance';
-import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@/shared/constant/api';
+import { HTTP_STATUS_CODE, STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 interface ErrorResponse {
@@ -17,7 +17,7 @@ interface ErrorResponse {
 export const handleCheckAndSetToken = (config: InternalAxiosRequestConfig) => {
   if (!config || !config.headers || config.headers.Authorization) return config;
 
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
   if (!accessToken) {
     window.location.replace(PATH.LOGIN);
@@ -40,12 +40,12 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
     try {
       const { data } = await getReissuedToken();
 
-      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+      localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN_KEY, data.accessToken);
       originRequest.data.headers.Authorization = `Bearer ${data.accessToken}`;
 
       return axiosInstance(originRequest);
     } catch (error) {
-      localStorage.removeItem(ACCESS_TOKEN_KEY);
+      localStorage.removeItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
       window.location.replace(PATH.LOGIN);
 
       throw new Error('토큰 갱신에 실패하였습니다.');

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 
 import { HTTPError } from '@/shared/api/HTTPError';
 import { getReissuedToken } from '@/shared/api/auth/reissue';
-import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@/shared/constant/api';
+import { HTTP_STATUS_CODE, STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 interface ErrorResponse {
@@ -17,7 +17,7 @@ interface ErrorResponse {
 /* 토큰 여부 확인 */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+    const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
     if (!accessToken) {
       window.location.replace(PATH.LOGIN);
@@ -45,7 +45,7 @@ export const tokenMiddleware: Middleware = {
     if (status === HTTP_STATUS_CODE.UNAUTHORIZED) {
       try {
         const { data } = await getReissuedToken();
-        localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+        localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN_KEY, data.accessToken);
 
         /* 기존의 Authorization 헤더를 갱신 후 재요청 */
         const newHeaders = {
@@ -62,7 +62,7 @@ export const tokenMiddleware: Middleware = {
 
         return newResponse;
       } catch (error) {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
         window.location.replace(PATH.LOGIN);
 
         throw new Error('토큰 갱신에 실패하였습니다.');

--- a/apps/client/src/shared/component/Header/Header.style.ts
+++ b/apps/client/src/shared/component/Header/Header.style.ts
@@ -6,13 +6,13 @@ export const headerStyle = css({
   flexDirection: 'column',
   gap: '2rem',
 
-  width: 'fit-content',
+  width: '100%',
 
   paddingBottom: '2rem',
 
   backgroundColor: theme.colors.white,
 
-  '& > h1': {
+  '& h1': {
     padding: '1rem',
 
     ...theme.heading.heading05,

--- a/apps/client/src/shared/component/Header/Header.tsx
+++ b/apps/client/src/shared/component/Header/Header.tsx
@@ -7,10 +7,11 @@ import { headerStyle } from '@/shared/component/Header/Header.style';
 import InviteButton from '@/shared/component/Header/InviteButton';
 import SettingButton from '@/shared/component/Header/SettingButton';
 import RouteNav from '@/shared/component/RouteNav/RouteNav';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
 const Header = () => {
-  const title = localStorage.getItem('teamName');
+  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME);
 
   const isDashboardPage = useMatch(PATH.DASHBOARD);
   const isWorkspaceSettingPage = useMatch(PATH.WORKSPACE_SETTING);

--- a/apps/client/src/shared/component/Header/Header.tsx
+++ b/apps/client/src/shared/component/Header/Header.tsx
@@ -1,26 +1,41 @@
-import { Heading } from '@tiki/ui';
+import { IcAlertYes } from '@tiki/icon';
+import { Flex, Heading } from '@tiki/ui';
 
 import { useMatch } from 'react-router-dom';
 
 import { headerStyle } from '@/shared/component/Header/Header.style';
+import InviteButton from '@/shared/component/Header/InviteButton';
+import SettingButton from '@/shared/component/Header/SettingButton';
 import RouteNav from '@/shared/component/RouteNav/RouteNav';
 import { PATH } from '@/shared/constant/path';
 
 const Header = () => {
-  /** TODO: 추후 global State 혹은 localStorage에 저장 */
-  const title = 'TIKI 워크스페이스';
+  const title = localStorage.getItem('teamName');
 
   const isDashboardPage = useMatch(PATH.DASHBOARD);
   const isWorkspaceSettingPage = useMatch(PATH.WORKSPACE_SETTING);
   const isInvitedPage = useMatch(PATH.INVITE_IN);
+  const isOnboardingPage = useMatch(PATH.ONBOARDING);
 
-  const isVisible = !isDashboardPage && !isWorkspaceSettingPage && !isInvitedPage;
+  const isRouteNavVisble = !isDashboardPage && !isWorkspaceSettingPage && !isInvitedPage && !isOnboardingPage;
+  const isTitleVisible = !isInvitedPage && !isOnboardingPage;
+  const isRightSideVisible = !isWorkspaceSettingPage && !isOnboardingPage && !isInvitedPage;
 
   return (
     <header css={headerStyle}>
-      <Heading tag="H1">{!isInvitedPage && title}</Heading>
+      <Flex styles={{ justify: 'space-between' }}>
+        {isTitleVisible && <Heading tag="H1">{title}</Heading>}
 
-      {isVisible && <RouteNav />}
+        {isRightSideVisible && (
+          <div css={{ display: 'flex', gap: '1.2rem', alignItems: 'center' }}>
+            <InviteButton />
+            <IcAlertYes css={{ cursor: 'pointer' }} width={16} height={16} />
+            <SettingButton />
+          </div>
+        )}
+      </Flex>
+
+      {isRouteNavVisble && <RouteNav />}
     </header>
   );
 };

--- a/apps/client/src/shared/component/Header/InviteButton.tsx
+++ b/apps/client/src/shared/component/Header/InviteButton.tsx
@@ -1,0 +1,18 @@
+import { IcAddTeam } from '@tiki/icon';
+import { Button } from '@tiki/ui';
+
+const InviteButton = () => {
+  return (
+    <Button
+      onClick={() => {
+        /** TODO: 초대 모달 오픈 */
+      }}
+      size="small"
+      variant="outline">
+      <IcAddTeam width={16} height={16} />
+      팀원 초대
+    </Button>
+  );
+};
+
+export default InviteButton;

--- a/apps/client/src/shared/component/Header/SettingButton.tsx
+++ b/apps/client/src/shared/component/Header/SettingButton.tsx
@@ -1,0 +1,20 @@
+import { IcSettingGray } from '@tiki/icon';
+import { Button } from '@tiki/ui';
+
+import { useNavigate } from 'react-router-dom';
+
+import { PATH } from '@/shared/constant/path';
+
+const SettingButton = () => {
+  const navigate = useNavigate();
+
+  const 워크스페이스설정페이지로 = () => navigate(PATH.WORKSPACE_SETTING);
+
+  return (
+    <Button onClick={워크스페이스설정페이지로} size="small" variant="outline">
+      <IcSettingGray width={16} height={16} />
+    </Button>
+  );
+};
+
+export default SettingButton;

--- a/apps/client/src/shared/component/Login/Login.tsx
+++ b/apps/client/src/shared/component/Login/Login.tsx
@@ -1,13 +1,13 @@
 import { ReactNode, useEffect } from 'react';
 
-import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { useAuth } from '@/shared/store/auth';
 
 const Login = ({ children }: { children: ReactNode }) => {
   const { login } = useAuth();
 
   useEffect(() => {
-    if (localStorage.getItem(ACCESS_TOKEN_KEY)) {
+    if (localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY)) {
       login();
     }
   }, [login]);

--- a/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
+++ b/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
@@ -8,6 +8,7 @@ import { components } from '@/shared/__generated__/schema';
 import { $api } from '@/shared/api/client';
 import Item from '@/shared/component/SideNavBar/Item/Item';
 import { containerStyle, settingStyle, tikiLogoStyle } from '@/shared/component/SideNavBar/SideNavBar.style';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import { useOpenModal } from '@/shared/store/modal';
 import { useTeamId, useTeamIdAction } from '@/shared/store/team';
@@ -31,8 +32,8 @@ const SideNavBar = () => {
     } else {
       setTeamId(info.id);
 
-      localStorage.setItem('teamId', String(info.id));
-      localStorage.setItem('teamName', info.name);
+      localStorage.setItem(STORAGE_KEY.TEAM_ID, String(info.id));
+      localStorage.setItem(STORAGE_KEY.TEAM_NAME, info.name);
 
       navigate(path);
     }

--- a/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
+++ b/apps/client/src/shared/component/SideNavBar/SideNavBar.tsx
@@ -4,13 +4,13 @@ import { Divider, Flex, ToolTip, theme } from '@tiki/ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { components } from '@/shared/__generated__/schema';
 import { $api } from '@/shared/api/client';
 import Item from '@/shared/component/SideNavBar/Item/Item';
 import { containerStyle, settingStyle, tikiLogoStyle } from '@/shared/component/SideNavBar/SideNavBar.style';
 import { PATH } from '@/shared/constant/path';
 import { useOpenModal } from '@/shared/store/modal';
 import { useTeamId, useTeamIdAction } from '@/shared/store/team';
-import { Team } from '@/shared/type/team';
 
 const SideNavBar = () => {
   const [isInShowcase, setIsInShowcase] = useState(false);
@@ -22,14 +22,18 @@ const SideNavBar = () => {
 
   const { data } = $api.useQuery('get', '/api/v1/members/teams');
 
-  const handleItemClick = (id: string, path: string) => {
-    if (id === 'showcase') {
+  const handleItemClick = (info: components['schemas']['BelongTeamGetResponse'] | null, path: string) => {
+    if (info === null) {
       setTeamId(null);
       setIsInShowcase(true);
+
       navigate(path);
     } else {
-      setTeamId(+id);
-      localStorage.setItem('teamId', id);
+      setTeamId(info.id);
+
+      localStorage.setItem('teamId', String(info.id));
+      localStorage.setItem('teamName', info.name);
+
       navigate(path);
     }
     close();
@@ -46,16 +50,16 @@ const SideNavBar = () => {
         <Item
           variant={{ type: 'dashboard', hoverMessage: 'showcase' }}
           isClicked={isInShowcase}
-          onLogoClick={() => handleItemClick('showcase', PATH.SHOWCASE)}
+          onLogoClick={() => handleItemClick(null, PATH.SHOWCASE)}
         />
         <Divider type="horizontal" size={56.78} color={theme.colors.gray_300} />
-        {data?.data?.belongTeamGetResponses.map((data: Team) => {
+        {data?.data?.belongTeamGetResponses.map((data) => {
           return (
             <Item
               key={data.id}
               isClicked={teamId === data.id}
               variant={{ type: 'team', logoUrl: data.iconImageUrl, hoverMessage: data.name }}
-              onLogoClick={() => handleItemClick(String(data.id), `${PATH.DASHBOARD}?teamId=${data.id}`)}
+              onLogoClick={() => handleItemClick(data, `${PATH.DASHBOARD}?teamId=${data.id}`)}
             />
           );
         })}

--- a/apps/client/src/shared/constant/api.ts
+++ b/apps/client/src/shared/constant/api.ts
@@ -1,8 +1,10 @@
-export const ACCESS_TOKEN_KEY = 'ACCESS_TOKEN' as const;
-
-export const INVITATION_ID = 'INVITATION_ID' as const;
-
-export const INVITE_TEAM_ID = 'INVITE_TEAM_ID' as const;
+export const STORAGE_KEY = {
+  ACCESS_TOKEN_KEY: 'ACCESS_TOKEN',
+  INVITATION_ID: 'INVITATION_ID',
+  INVITE_TEAM_ID: 'INVITE_TEAM_ID',
+  TEAM_ID: 'TEAM_ID',
+  TEAM_NAME: 'TEAM_NAME',
+} as const;
 
 export const HTTP_STATUS_CODE = {
   SUCCESS: 200,

--- a/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
+++ b/apps/client/src/shared/hook/common/useInitializeTeamId.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { paths } from '@/shared/__generated__/schema';
 import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import { useTeamIdAction } from '@/shared/store/team';
 
@@ -19,7 +20,7 @@ export const useInitializeTeamId = () => {
   });
 
   useEffect(() => {
-    if (isSuccess && !localStorage.getItem('teamId')) {
+    if (isSuccess && !localStorage.getItem(STORAGE_KEY.TEAM_ID)) {
       if (data.data?.belongTeamGetResponses.length === 0) {
         navigate(PATH.ONBOARDING);
 
@@ -27,12 +28,12 @@ export const useInitializeTeamId = () => {
       }
       const teamId = data.data?.belongTeamGetResponses[0].id ?? 0;
 
-      localStorage.setItem('teamId', teamId!.toString());
+      localStorage.setItem(STORAGE_KEY.TEAM_ID, teamId!.toString());
       setTeamId(teamId);
     } else if (!isSuccess) {
       navigate(PATH.LOGIN);
     }
   });
 
-  return Number(localStorage.getItem('teamId'));
+  return Number(localStorage.getItem(STORAGE_KEY.TEAM_ID));
 };

--- a/apps/client/src/shared/store/team.ts
+++ b/apps/client/src/shared/store/team.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import { STORAGE_KEY } from '@/shared/constant/api';
+
 type TeamStore = {
   teamId: number | null;
   actions: {
@@ -8,7 +10,7 @@ type TeamStore = {
 };
 
 const useTeamStore = create<TeamStore>((set) => ({
-  teamId: Number(localStorage.getItem('teamId')),
+  teamId: Number(localStorage.getItem(STORAGE_KEY.TEAM_ID)),
 
   actions: {
     setTeamId: (teamId: number | null) =>


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #440

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

헤더에 "팀원 초대", 알람, "설정" 버튼을 추가해주었습니다. 추가적으로 현재 라우트에 따른 헤더의 `visible` 여부도 추가해주었어요 !

팀원 초대 모달 로직 연결은 다은님이 이어서 해주시기로 했습니다. 그리고 `invite`를 `url`에 그대로 입력하게 하면 안될 것 같아요. 항상 팀원 초대 메일을 받은 후 리다이렉트로만 접근 가능하도록 수정해야할 것 같습니다. 어떻게 생각하시나요 ?

---

## 📌스크린샷 (선택)

<img width="1363" alt="image" src="https://github.com/user-attachments/assets/48b1d32f-f1cc-4e89-bf01-69095f597586" />

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/1aa2b9f8-d3f4-4d5f-9aa8-cc7133335c64" />

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/8b9a1644-86f4-41ab-bbcd-fc33c88ba212" />

