### PR TITLE
[Feat] 초대페이지 기능및디자인 QA 

### DIFF
--- a/apps/client/.storybook/main.ts
+++ b/apps/client/.storybook/main.ts
@@ -1,25 +1,30 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
 function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, 'package.json')));
+  return dirname(import.meta.resolve(join(value, 'package.json')));
 }
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    getAbsolutePath('@storybook/addon-links'),
-    getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@storybook/addon-onboarding'),
-    getAbsolutePath('@storybook/addon-interactions'),
-    getAbsolutePath('@storybook/addon-a11y'),
-    getAbsolutePath('@chromatic-com/storybook'),
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+    '@chromatic-com/storybook',
   ],
+
   framework: {
-    name: getAbsolutePath('@storybook/react-vite'),
+    name: '@storybook/react-vite',
     options: {},
   },
   docs: {
@@ -29,15 +34,15 @@ const config: StorybookConfig = {
     const { mergeConfig } = await import('vite');
 
     if (config.resolve) {
-      (config.resolve.preserveSymlinks = true),
-        (config.resolve.alias = {
-          ...config.resolve.alias,
-          '@': resolve(__dirname, '../src'),
-          '@/common': resolve(__dirname, '../src/common'),
-          '@/page': resolve(__dirname, '../src/page'),
-          '@/shared': resolve(__dirname, '../src/shared'),
-          '@tiki/ui': resolve(__dirname, '../../../packages/ui/dist'),
-        });
+      config.resolve.preserveSymlinks = true;
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@': resolve(__dirname, '../src'),
+        '@/common': resolve(__dirname, '../src/common'),
+        '@/page': resolve(__dirname, '../src/page'),
+        '@/shared': resolve(__dirname, '../src/shared'),
+        '@tiki/ui': resolve(__dirname, '../../../packages/ui/dist'),
+      };
     }
 
     return mergeConfig(config, {
@@ -45,4 +50,5 @@ const config: StorybookConfig = {
     });
   },
 };
+
 export default config;

--- a/apps/client/.storybook/main.ts
+++ b/apps/client/.storybook/main.ts
@@ -1,16 +1,17 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import { dirname, join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+//import { fileURLToPath } from 'url';
 
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
+/*
 function getAbsolutePath(value: string): any {
   return dirname(import.meta.resolve(join(value, 'package.json')));
-}
+}*/
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+//const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],

--- a/apps/client/.storybook/preview.tsx
+++ b/apps/client/.storybook/preview.tsx
@@ -11,7 +11,6 @@ import { GlobalStyle } from '../src/common/style/globalStyle';
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --project-token=chpt_f4088febbfb82b7",
+    "chromatic": "npx chromatic --force-rebuild",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --force-rebuild",
+    "chromatic": "npx chromatic --project-token=chpt_f4088febbfb82b7",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
+++ b/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
@@ -9,8 +9,9 @@ export const adderStyle = (path: string) =>
     justifyContent: 'center',
     alignItems: 'center',
 
-    padding: path === PATH.DRIVE ? '4rem 6rem' : path === PATH.HANDOVER ? '3rem' : '9.8rem',
+    padding: path === PATH.DRIVE ? '4rem 6rem' : '3rem',
 
+    minHeight: path === PATH.ARCHIVING ? 'calc(100vh - 53rem)' : '',
     width: path !== PATH.DRIVE ? '100%' : '',
 
     border: 'none',

--- a/apps/client/src/page/invite/constant/index.ts
+++ b/apps/client/src/page/invite/constant/index.ts
@@ -1,0 +1,6 @@
+export const MESSAGE = {
+  INVITE_SUCCESS: '초대 승인에 성공하셨습니다.',
+  DENY_SUCCESS: '초대 거절에 성공하셨습니다.',
+  INVITE_FAILED: '초대 승인에 실패하셨습니다.',
+  DENY_FAILED: '초대 거절에 실패하셨습니다.',
+};

--- a/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
+++ b/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
@@ -11,7 +11,8 @@ export const useInvitationInfo = () => {
   localStorage.setItem(STORAGE_KEY.INVITATION_ID, invitationId);
   localStorage.setItem(STORAGE_KEY.INVITE_TEAM_ID, inviteTeamId);
 
-  const { data } = useGetInvitationInfo(+invitationId);
+  const { data, ...rest } = useGetInvitationInfo(+invitationId);
+  console.log(rest);
 
   return { data, invitationId };
 };

--- a/apps/client/src/page/invite/index.styles.ts
+++ b/apps/client/src/page/invite/index.styles.ts
@@ -27,3 +27,12 @@ export const firstSpellStyle = css({
 
   fontSize: '2rem',
 });
+
+export const redButtonStyle = css({
+  color: theme.colors.sementic_red,
+  backgroundColor: theme.colors.sementic_red_10,
+
+  ':hover': {
+    backgroundColor: theme.colors.sementic_red_20,
+  },
+});

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -4,6 +4,8 @@ import { Button, Flex, Heading, Text, useToastAction } from '@tiki/ui';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { MESSAGE } from '@/page/invite/constant';
 import { useInvitationInfo } from '@/page/invite/hook/common/useInvitationInfo';
 import { useApproveInvitation, useDenyInvitation } from '@/page/invite/hook/queries';
@@ -17,6 +19,8 @@ const InvitedPage = () => {
   const isLogined = !!localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
   const { createToast } = useToastAction();
+
+  const queryClient = useQueryClient();
 
   const [invitationInfo, setInvitationInfo] = useState<InvitationType>();
   const [teamId, setTeamId] = useState<number>(0);
@@ -55,7 +59,10 @@ const InvitedPage = () => {
       {
         onSuccess: () => {
           createToast(MESSAGE.INVITE_SUCCESS, 'success');
-          window.location.replace(PATH.DASHBOARD);
+
+          queryClient.invalidateQueries({ queryKey: ['get', '/api/v1/members/teams'] });
+          navigate(PATH.DASHBOARD);
+
           localStorage.setItem(STORAGE_KEY.TEAM_ID, `${teamId}`);
           localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${invitationInfo?.teamName}`);
         },

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -4,12 +4,12 @@ import { Button, Flex, Heading, Text, useToastAction } from '@tiki/ui';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { MESSAGE } from '@/page/invite/constant';
 import { useInvitationInfo } from '@/page/invite/hook/common/useInvitationInfo';
 import { useApproveInvitation, useDenyInvitation } from '@/page/invite/hook/queries';
 import { firstSpellStyle, inviteStyle, redButtonStyle } from '@/page/invite/index.styles';
 import { InvitationType } from '@/page/invite/type';
 
-import { components } from '@/shared/__generated__/schema';
 import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
@@ -37,7 +37,7 @@ const InvitedPage = () => {
     }
   }, [createToast, data, invitationInfo?.teamId, isLogined, navigate]);
 
-  const deleteLocalStorageInviteInfo = () => {
+  const clearInvitation = () => {
     localStorage.removeItem(STORAGE_KEY.INVITATION_ID);
     localStorage.removeItem(STORAGE_KEY.INVITE_TEAM_ID);
   };
@@ -54,18 +54,18 @@ const InvitedPage = () => {
       },
       {
         onSuccess: () => {
-          createToast('초대 승인에 성공하셨습니다.', 'success');
+          createToast(MESSAGE.INVITE_SUCCESS, 'success');
           window.location.replace(PATH.DASHBOARD);
           localStorage.setItem(STORAGE_KEY.TEAM_ID, `${teamId}`);
           localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${invitationInfo?.teamName}`);
         },
-        onError: (error: components['schemas']['ErrorResponse']) => {
-          createToast(`초대 승인에 실패하셨습니다: ${error.message}`, 'error');
+        onError: () => {
+          createToast(MESSAGE.INVITE_FAILED, 'error');
           navigate(PATH.ONBOARDING);
         },
       }
     );
-    deleteLocalStorageInviteInfo();
+    clearInvitation();
   };
 
   const handleDenyInvitation = () => {
@@ -79,14 +79,14 @@ const InvitedPage = () => {
       },
       {
         onSuccess: () => {
-          createToast('초대 거절에 성공하셨습니다.', 'success');
+          createToast(MESSAGE.DENY_SUCCESS, 'success');
         },
-        onError: (error: components['schemas']['ErrorResponse']) => {
-          createToast(`초대 거절에 실패하셨습니다: ${error.message}`, 'error');
+        onError: () => {
+          createToast(MESSAGE.DENY_FAILED, 'error');
         },
       }
     );
-    deleteLocalStorageInviteInfo();
+    clearInvitation();
     navigate(PATH.ONBOARDING);
   };
 

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -55,9 +55,9 @@ const InvitedPage = () => {
       {
         onSuccess: () => {
           createToast('초대 승인에 성공하셨습니다.', 'success');
+          window.location.replace(PATH.DASHBOARD);
           localStorage.setItem(STORAGE_KEY.TEAM_ID, `${teamId}`);
           localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${invitationInfo?.teamName}`);
-          navigate(PATH.DASHBOARD);
         },
         onError: (error: components['schemas']['ErrorResponse']) => {
           createToast(`초대 승인에 실패하셨습니다: ${error.message}`, 'error');

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -1,12 +1,12 @@
 import { LogoTikiSm } from '@tiki/icon';
-import { Button, Flex, Heading, Text, theme, useToastAction } from '@tiki/ui';
+import { Button, Flex, Heading, Text, useToastAction } from '@tiki/ui';
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useInvitationInfo } from '@/page/invite/hook/common/useInvitationInfo';
 import { useApproveInvitation, useDenyInvitation } from '@/page/invite/hook/queries';
-import { firstSpellStyle, inviteStyle } from '@/page/invite/index.styles';
+import { firstSpellStyle, inviteStyle, redButtonStyle } from '@/page/invite/index.styles';
 import { InvitationType } from '@/page/invite/type';
 
 import { components } from '@/shared/__generated__/schema';
@@ -54,17 +54,18 @@ const InvitedPage = () => {
       },
       {
         onSuccess: () => {
-          deleteLocalStorageInviteInfo();
+          createToast('초대 승인에 성공하셨습니다.', 'success');
           localStorage.setItem(STORAGE_KEY.TEAM_ID, `${teamId}`);
+          localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${invitationInfo?.teamName}`);
           navigate(PATH.DASHBOARD);
         },
         onError: (error: components['schemas']['ErrorResponse']) => {
-          deleteLocalStorageInviteInfo();
-          createToast(error.message, 'error');
+          createToast(`초대 승인에 실패하셨습니다: ${error.message}`, 'error');
           navigate(PATH.ONBOARDING);
         },
       }
     );
+    deleteLocalStorageInviteInfo();
   };
 
   const handleDenyInvitation = () => {
@@ -78,16 +79,15 @@ const InvitedPage = () => {
       },
       {
         onSuccess: () => {
-          deleteLocalStorageInviteInfo();
-          navigate(PATH.ONBOARDING);
+          createToast('초대 거절에 성공하셨습니다.', 'success');
         },
         onError: (error: components['schemas']['ErrorResponse']) => {
-          deleteLocalStorageInviteInfo();
-          createToast(error.message, 'error');
-          navigate(PATH.ONBOARDING);
+          createToast(`초대 거절에 실패하셨습니다: ${error.message}`, 'error');
         },
       }
     );
+    deleteLocalStorageInviteInfo();
+    navigate(PATH.ONBOARDING);
   };
 
   return (
@@ -114,10 +114,7 @@ const InvitedPage = () => {
             <Button size="xLarge" variant="secondary" onClick={handleApproveInvitation}>
               초대 수락
             </Button>
-            <Button
-              size="xLarge"
-              css={{ color: theme.colors.sementic_red, backgroundColor: theme.colors.sementic_red_10 }}
-              onClick={handleDenyInvitation}>
+            <Button size="xLarge" css={redButtonStyle} onClick={handleDenyInvitation}>
               거절하기
             </Button>
           </Flex>

--- a/apps/client/src/page/invite/index.tsx
+++ b/apps/client/src/page/invite/index.tsx
@@ -126,7 +126,7 @@ const InvitedPage = () => {
             </Button>
           </Flex>
         ) : (
-          <Button size="xLarge" css={{ width: '100%' }}>
+          <Button size="xLarge" css={{ width: '100%' }} onClick={() => navigate(PATH.LOGIN)}>
             로그인하고 초대수락하기
           </Button>
         )}

--- a/apps/client/src/page/onboarding/index.tsx
+++ b/apps/client/src/page/onboarding/index.tsx
@@ -1,15 +1,32 @@
 import { Button, Flex, Heading, Text } from '@tiki/ui';
 
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import { pageStyle, textStyle } from '@/page/onboarding/index.style';
 
+import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
+import { PATH } from '@/shared/constant/path';
 import { useOpenModal } from '@/shared/store/modal';
 
 const OnBoardingPage = () => {
+  const navigate = useNavigate();
   const openModal = useOpenModal();
 
   const handleCreateWorkSpace = () => {
     openModal('create-workspace');
   };
+
+  const { data } = $api.useQuery('get', '/api/v1/members/teams');
+  const firstTeam = data?.data?.belongTeamGetResponses[0];
+  useEffect(() => {
+    if (firstTeam) {
+      localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
+      localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
+      navigate(PATH.DASHBOARD);
+    }
+  }, [firstTeam, navigate]);
 
   return (
     <Flex css={pageStyle}>

--- a/apps/client/src/page/onboarding/index.tsx
+++ b/apps/client/src/page/onboarding/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Flex, Heading, Text } from '@tiki/ui';
 
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { pageStyle, textStyle } from '@/page/onboarding/index.style';
@@ -18,15 +17,15 @@ const OnBoardingPage = () => {
     openModal('create-workspace');
   };
 
-  const { data } = $api.useQuery('get', '/api/v1/members/teams');
+  const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams');
+
   const firstTeam = data?.data?.belongTeamGetResponses[0];
-  useEffect(() => {
-    if (firstTeam) {
-      localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
-      localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
-      navigate(PATH.DASHBOARD);
-    }
-  }, [firstTeam, navigate]);
+
+  if (firstTeam && isSuccess) {
+    localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
+    localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
+    navigate(PATH.DASHBOARD);
+  }
 
   return (
     <Flex css={pageStyle}>

--- a/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
+++ b/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
@@ -8,6 +8,7 @@ import { POSITION } from '@/page/workspaceSetting/constant';
 import { workspaceDeleteButton } from '@/page/workspaceSetting/styles';
 
 import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 import { useCloseModal, useOpenModal } from '@/shared/store/modal';
@@ -32,6 +33,29 @@ const WorkspaceDelete = ({ position }: WorkspaceDeleteProps) => {
   const handleDelete = () => {
     if (position === POSITION.ADMIN) {
       deleteTeam(
+        { params: { path: { teamId } } },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({
+              queryKey: ['get', '/api/v1/members/teams'],
+            });
+
+            closeModal();
+
+            localStorage.removeItem(STORAGE_KEY.TEAM_ID);
+            localStorage.removeItem(STORAGE_KEY.TEAM_NAME);
+
+            navigate(PATH.DASHBOARD);
+          },
+          onError: () => {
+            createToast(`워크스페이스 ${TYPE} 과정에서 오류가 발생했습니다`, 'error');
+          },
+        }
+      );
+    }
+
+    if (position === POSITION.EXECUTIVE) {
+      leaveTeam(
         { params: { path: { teamId } } },
         {
           onSuccess: () => {

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -19,11 +19,9 @@ export const authMiddleware: Middleware = {
   async onRequest({ request }) {
     const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
-    if (!accessToken) {
-      if (!localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
-        window.location.replace(PATH.LOGIN);
-        throw new Error('토큰이 존재하지 않습니다.');
-      }
+    if (!accessToken && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+      window.location.replace(PATH.LOGIN);
+      throw new Error('토큰이 존재하지 않습니다.');
     }
 
     request.headers.set('Authorization', `Bearer ${accessToken}`);

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -20,8 +20,10 @@ export const authMiddleware: Middleware = {
     const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
     if (!accessToken) {
-      window.location.replace(PATH.LOGIN);
-      throw new Error('토큰이 존재하지 않습니다.');
+      if (!localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+        window.location.replace(PATH.LOGIN);
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
     }
 
     request.headers.set('Authorization', `Bearer ${accessToken}`);

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -17,16 +17,18 @@ interface ErrorResponse {
 /* 토큰 여부 확인 */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
+    if (localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY) || !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+      const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
-    if (!accessToken && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
-      window.location.replace(PATH.LOGIN);
-      throw new Error('토큰이 존재하지 않습니다.');
+      if (!accessToken) {
+        window.location.replace(PATH.LOGIN);
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
+
+      request.headers.set('Authorization', `Bearer ${accessToken}`);
+
+      return request;
     }
-
-    request.headers.set('Authorization', `Bearer ${accessToken}`);
-
-    return request;
   },
 };
 

--- a/apps/client/src/shared/component/Header/Header.tsx
+++ b/apps/client/src/shared/component/Header/Header.tsx
@@ -2,6 +2,8 @@ import { Flex, Heading } from '@tiki/ui';
 
 import { useMatch, useNavigate } from 'react-router-dom';
 
+import { useTeamData } from '@/page/workspaceSetting/hook/api/queries';
+
 import AlarmButton from '@/shared/component/Header/AlarmButton';
 import { headerStyle } from '@/shared/component/Header/Header.style';
 import InviteButton from '@/shared/component/Header/InviteButton';
@@ -13,7 +15,8 @@ import { PATH } from '@/shared/constant/path';
 const Header = () => {
   const navigate = useNavigate();
 
-  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME);
+  const { data } = useTeamData();
+  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME) || data?.data?.teamName;
 
   const isDashboardPage = useMatch(PATH.DASHBOARD);
   const isWorkspaceSettingPage = useMatch(PATH.WORKSPACE_SETTING);

--- a/apps/client/src/shared/component/Header/Header.tsx
+++ b/apps/client/src/shared/component/Header/Header.tsx
@@ -2,8 +2,6 @@ import { Flex, Heading } from '@tiki/ui';
 
 import { useMatch, useNavigate } from 'react-router-dom';
 
-import { useTeamData } from '@/page/workspaceSetting/hook/api/queries';
-
 import AlarmButton from '@/shared/component/Header/AlarmButton';
 import { headerStyle } from '@/shared/component/Header/Header.style';
 import InviteButton from '@/shared/component/Header/InviteButton';
@@ -15,8 +13,7 @@ import { PATH } from '@/shared/constant/path';
 const Header = () => {
   const navigate = useNavigate();
 
-  const { data } = useTeamData();
-  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME) || data?.data?.teamName;
+  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME);
 
   const isDashboardPage = useMatch(PATH.DASHBOARD);
   const isWorkspaceSettingPage = useMatch(PATH.WORKSPACE_SETTING);

--- a/apps/client/src/shared/component/Header/Header.tsx
+++ b/apps/client/src/shared/component/Header/Header.tsx
@@ -2,6 +2,8 @@ import { Flex, Heading } from '@tiki/ui';
 
 import { useMatch, useNavigate } from 'react-router-dom';
 
+import { useTeamData } from '@/page/workspaceSetting/hook/api/queries';
+
 import AlarmButton from '@/shared/component/Header/AlarmButton';
 import { headerStyle } from '@/shared/component/Header/Header.style';
 import InviteButton from '@/shared/component/Header/InviteButton';
@@ -12,7 +14,9 @@ import { PATH } from '@/shared/constant/path';
 
 const Header = () => {
   const navigate = useNavigate();
-  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME);
+
+  const { data } = useTeamData();
+  const title = localStorage.getItem(STORAGE_KEY.TEAM_NAME) || data?.data?.teamName;
 
   const isDashboardPage = useMatch(PATH.DASHBOARD);
   const isWorkspaceSettingPage = useMatch(PATH.WORKSPACE_SETTING);


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #463 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [ ] ✅ 컨벤션을 지켰나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [ ] 🙇‍♂️ 리뷰어를 지정했나요? 
---

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
- useNavigate vs window.location.replace
navigate는 진짜 경로만 옮겨주는데요 window.location.replace는 새로고침까지 해줘요!
그래서 바뀐 것들이 반영이 아주 잘된답니다 😄 
---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
1. 대시보드의 height가 늘어나지 않아서 못생긴 이슈가 있었습니다.
- 이것을 `cal(100vh - 어쩌구)`로 반응형으로 해결할 수 있었습니다.
2. 팀이 있는 유저가 로그인했을때 토큰만있고 TEAM_ID가 없는 경우에 onboarding으로 이동하는 이슈가 있었습니다. (즉, snb에는 팀이 있는데 대시보드 페이지가 아닌 온보딩페이지로 가는 현상!)
- 이것을 Onboarding 페이지에서 내가 속한 팀을 가져오고 useEffect를 이용해 팀이 존재하면 로컬스토리지에 TEAM_ID등을 set하고 대시보드로 이동시켜 해결했습니다.
```  
const { data } = $api.useQuery('get', '/api/v1/members/teams');
 const firstTeam = data?.data?.belongTeamGetResponses[0];
useEffect(() => {
    if (firstTeam) {
      localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
      localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
      navigate(PATH.DASHBOARD);
    }
```
3. 로그인 하지 않은 상태로 초대를 받을 때, 로그인페이지로 인터셉트 당하여 아래 페이지가 나오지 않는 이슈가 있었습니다.
<img width="558" alt="image" src="https://github.com/user-attachments/assets/0f540a6a-1931-44a2-911e-e33674c22309" />

- 이는 `middleware.ts`에서 토큰여부확인하는 로직을 수정했습니다. 
- 원래는 `accessToken`만 없으면 바로 로그인페이지로 이동하게 되어있었는데, 
- 초대를 받으면 로컬스토리지에 INVITATION_ID를 저장하고 그것을 이용해 로컬스토리지에 초대 아이디가 있는지 까지 확인 한 후에 토큰과 초대아이디 모두 없을때 로그인페이지로 이동합니다.
```
if (!accessToken && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
      window.location.replace(PATH.LOGIN);
      throw new Error('토큰이 존재하지 않습니다.');
    }
```
- (로컬스토리지의 초대아이디는 초대와 관련된 로직이 끝나면 삭제됩니다)

---

## 📌스크린샷 (선택)
