### PR TITLE
[Feat] 초대페이지 로직 수정 QA_2

### DIFF
--- a/apps/client/src/page/dashboard/DashboardPage.tsx
+++ b/apps/client/src/page/dashboard/DashboardPage.tsx
@@ -7,8 +7,8 @@ import { contentBoxStyle, handoverBoxStyle } from '@/page/dashboard/DashboardPag
 import FileSection from '@/page/dashboard/component/File/FileSection';
 import HandoverSection from '@/page/dashboard/component/Handover/HandoverSection';
 import TimelineSection from '@/page/dashboard/component/Timeline';
-import { useTeamData } from '@/page/workspaceSetting/hook/api/queries';
 
+import { $api } from '@/shared/api/client';
 import ContentBox from '@/shared/component/ContentBox/ContentBox';
 import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
@@ -20,15 +20,19 @@ const DashboardPage = () => {
     navigate(path);
   };
 
-  const { data } = useTeamData();
-
-  if (!localStorage.getItem(STORAGE_KEY.TEAM_NAME)) {
-    localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${data?.data?.teamName}`);
+  if (!localStorage.getItem(STORAGE_KEY.TEAM_ID)) {
+    navigate(PATH.ONBOARDING);
   }
+
+  const { data } = $api.useQuery('get', '/api/v1/members/teams');
 
   useEffect(() => {
     if (localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
       navigate(`${PATH.INVITE}/${localStorage.getItem(STORAGE_KEY.INVITE_TEAM_ID)}`);
+    }
+    if (!localStorage.getItem(STORAGE_KEY.TEAM_NAME) && data?.data?.belongTeamGetResponses[0]) {
+      localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${data?.data?.belongTeamGetResponses[0].name}`);
+      console.log('TITLE::', data?.data?.belongTeamGetResponses[0].name);
     }
   });
 

--- a/apps/client/src/page/dashboard/DashboardPage.tsx
+++ b/apps/client/src/page/dashboard/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { contentBoxStyle, handoverBoxStyle } from '@/page/dashboard/DashboardPag
 import FileSection from '@/page/dashboard/component/File/FileSection';
 import HandoverSection from '@/page/dashboard/component/Handover/HandoverSection';
 import TimelineSection from '@/page/dashboard/component/Timeline';
+import { useTeamData } from '@/page/workspaceSetting/hook/api/queries';
 
 import ContentBox from '@/shared/component/ContentBox/ContentBox';
 import { STORAGE_KEY } from '@/shared/constant/api';
@@ -18,6 +19,12 @@ const DashboardPage = () => {
   const handleNav = (path: string) => {
     navigate(path);
   };
+
+  const { data } = useTeamData();
+
+  if (!localStorage.getItem(STORAGE_KEY.TEAM_NAME)) {
+    localStorage.setItem(STORAGE_KEY.TEAM_NAME, `${data?.data?.teamName}`);
+  }
 
   useEffect(() => {
     if (localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {

--- a/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
+++ b/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
@@ -9,8 +9,9 @@ export const adderStyle = (path: string) =>
     justifyContent: 'center',
     alignItems: 'center',
 
-    padding: path === PATH.DRIVE ? '4rem 6rem' : path === PATH.HANDOVER ? '3rem' : '9.8rem',
+    padding: path === PATH.DRIVE ? '4rem 6rem' : '3rem',
 
+    minHeight: path === PATH.ARCHIVING ? 'calc(100vh - 53rem)' : '',
     width: path !== PATH.DRIVE ? '100%' : '',
 
     border: 'none',

--- a/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
+++ b/apps/client/src/page/dashboard/component/ItemAdder/ItemAdder.styles.ts
@@ -11,8 +11,12 @@ export const adderStyle = (path: string) =>
 
     padding: path === PATH.DRIVE ? '4rem 6rem' : '3rem',
 
-    minHeight: path === PATH.ARCHIVING ? 'calc(100vh - 53rem)' : '',
-    width: path !== PATH.DRIVE ? '100%' : '',
+    ...(path !== PATH.DRIVE && {
+      width: '100%',
+    }),
+    ...(path === PATH.ARCHIVING && {
+      minHeight: 'calc(100vh - 53rem)',
+    }),
 
     border: 'none',
     borderRadius: '8px',

--- a/apps/client/src/page/invite/constant/index.ts
+++ b/apps/client/src/page/invite/constant/index.ts
@@ -1,0 +1,6 @@
+export const MESSAGE = {
+  INVITE_SUCCESS: '초대 승인에 성공하셨습니다.',
+  DENY_SUCCESS: '초대 거절에 성공하셨습니다.',
+  INVITE_FAILED: '초대 승인에 실패하셨습니다.',
+  DENY_FAILED: '초대 거절에 실패하셨습니다.',
+};

--- a/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
+++ b/apps/client/src/page/invite/hook/common/useInvitationInfo.ts
@@ -11,7 +11,7 @@ export const useInvitationInfo = () => {
   localStorage.setItem(STORAGE_KEY.INVITATION_ID, invitationId);
   localStorage.setItem(STORAGE_KEY.INVITE_TEAM_ID, inviteTeamId);
 
-  const { data } = useGetInvitationInfo(+invitationId);
+  const { data, failureCount } = useGetInvitationInfo(+invitationId);
 
-  return { data, invitationId };
+  return { data, invitationId, failureCount };
 };

--- a/apps/client/src/page/invite/index.styles.ts
+++ b/apps/client/src/page/invite/index.styles.ts
@@ -27,3 +27,12 @@ export const firstSpellStyle = css({
 
   fontSize: '2rem',
 });
+
+export const redButtonStyle = css({
+  color: theme.colors.sementic_red,
+  backgroundColor: theme.colors.sementic_red_10,
+
+  ':hover': {
+    backgroundColor: theme.colors.sementic_red_20,
+  },
+});

--- a/apps/client/src/page/onboarding/index.tsx
+++ b/apps/client/src/page/onboarding/index.tsx
@@ -17,6 +17,10 @@ const OnBoardingPage = () => {
     openModal('create-workspace');
   };
 
+  if (localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+    navigate(`${PATH.INVITE}/${localStorage.getItem(STORAGE_KEY.INVITE_TEAM_ID)}`);
+  }
+
   const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams');
 
   const firstTeam = data?.data?.belongTeamGetResponses[0];

--- a/apps/client/src/page/onboarding/index.tsx
+++ b/apps/client/src/page/onboarding/index.tsx
@@ -1,15 +1,31 @@
 import { Button, Flex, Heading, Text } from '@tiki/ui';
 
+import { useNavigate } from 'react-router-dom';
+
 import { pageStyle, textStyle } from '@/page/onboarding/index.style';
 
+import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
+import { PATH } from '@/shared/constant/path';
 import { useOpenModal } from '@/shared/store/modal';
 
 const OnBoardingPage = () => {
+  const navigate = useNavigate();
   const openModal = useOpenModal();
 
   const handleCreateWorkSpace = () => {
     openModal('create-workspace');
   };
+
+  const { data, isSuccess } = $api.useQuery('get', '/api/v1/members/teams');
+
+  const firstTeam = data?.data?.belongTeamGetResponses[0];
+
+  if (firstTeam && isSuccess) {
+    localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
+    localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
+    navigate(PATH.DASHBOARD);
+  }
 
   return (
     <Flex css={pageStyle}>

--- a/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
+++ b/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
@@ -8,6 +8,7 @@ import { POSITION } from '@/page/workspaceSetting/constant';
 import { workspaceDeleteButton } from '@/page/workspaceSetting/styles';
 
 import { $api } from '@/shared/api/client';
+import { STORAGE_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import { useInitializeTeamId } from '@/shared/hook/common/useInitializeTeamId';
 import { useCloseModal, useOpenModal } from '@/shared/store/modal';
@@ -41,7 +42,8 @@ const WorkspaceDelete = ({ position }: WorkspaceDeleteProps) => {
 
             closeModal();
 
-            localStorage.removeItem('teamId');
+            localStorage.removeItem(STORAGE_KEY.TEAM_ID);
+            localStorage.removeItem(STORAGE_KEY.TEAM_NAME);
 
             navigate(PATH.DASHBOARD);
           },

--- a/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
+++ b/apps/client/src/page/workspaceSetting/component/WorkspaceDelete.tsx
@@ -35,11 +35,10 @@ const WorkspaceDelete = ({ position }: WorkspaceDeleteProps) => {
       deleteTeam(
         { params: { path: { teamId } } },
         {
-          onSuccess: () => {
-            queryClient.invalidateQueries({
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
               queryKey: ['get', '/api/v1/members/teams'],
             });
-
             closeModal();
 
             localStorage.removeItem(STORAGE_KEY.TEAM_ID);
@@ -58,14 +57,14 @@ const WorkspaceDelete = ({ position }: WorkspaceDeleteProps) => {
       leaveTeam(
         { params: { path: { teamId } } },
         {
-          onSuccess: () => {
-            queryClient.invalidateQueries({
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
               queryKey: ['get', '/api/v1/members/teams'],
             });
-
             closeModal();
 
-            localStorage.removeItem('teamId');
+            localStorage.removeItem(STORAGE_KEY.TEAM_ID);
+            localStorage.removeItem(STORAGE_KEY.TEAM_NAME);
 
             navigate(PATH.DASHBOARD);
           },

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -17,8 +17,7 @@ interface ErrorResponse {
 /* 토큰 여부 확인 */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const isInvitationIdNone =
-      !localStorage.getItem(STORAGE_KEY.INVITATION_ID) || localStorage.getItem(STORAGE_KEY.INVITATION_ID) === '';
+    const isInvitationIdNone = !localStorage.getItem(STORAGE_KEY.INVITATION_ID);
 
     if (isInvitationIdNone) {
       const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -17,7 +17,10 @@ interface ErrorResponse {
 /* 토큰 여부 확인 */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    if (localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY) && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+    const isInvitationIdNone =
+      !localStorage.getItem(STORAGE_KEY.INVITATION_ID) || localStorage.getItem(STORAGE_KEY.INVITATION_ID) === '';
+
+    if (isInvitationIdNone) {
       const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
       if (!accessToken) {

--- a/apps/client/src/shared/api/middleware.ts
+++ b/apps/client/src/shared/api/middleware.ts
@@ -17,16 +17,18 @@ interface ErrorResponse {
 /* 토큰 여부 확인 */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
+    if (localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY) && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
+      const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN_KEY);
 
-    if (!accessToken) {
-      window.location.replace(PATH.LOGIN);
-      throw new Error('토큰이 존재하지 않습니다.');
+      if (!accessToken) {
+        window.location.replace(PATH.LOGIN);
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
+
+      request.headers.set('Authorization', `Bearer ${accessToken}`);
+
+      return request;
     }
-
-    request.headers.set('Authorization', `Bearer ${accessToken}`);
-
-    return request;
   },
 };
 


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #481 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
---


## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- 이전에 올렸던 피알 브랜치에서 스토리북 및 깃헙 액션 이슈가 있어 브랜치를 새로 팠습니다.
1. 대시보드의 height가 늘어나지 않아서 못생긴 이슈가 있었습니다.
- 이것을 `cal(100vh - 어쩌구)`로 반응형으로 해결할 수 있었습니다.
2. 팀이 있는 유저가 로그인했을때 토큰만있고 TEAM_ID가 없는 경우에 onboarding으로 이동하는 이슈가 있었습니다. (즉, snb에는 팀이 있는데 대시보드 페이지가 아닌 온보딩페이지로 가는 현상!)
- 이것을 Onboarding 페이지에서 내가 속한 팀을 가져오고 useEffect를 이용해 팀이 존재하면 로컬스토리지에 TEAM_ID등을 set하고 대시보드로 이동시켜 해결했습니다.
```  
const { data } = $api.useQuery('get', '/api/v1/members/teams');
 const firstTeam = data?.data?.belongTeamGetResponses[0];
useEffect(() => {
    if (firstTeam) {
      localStorage.setItem(STORAGE_KEY.TEAM_ID, String(firstTeam.id));
      localStorage.setItem(STORAGE_KEY.TEAM_NAME, firstTeam.name);
      navigate(PATH.DASHBOARD);
    }
```
3. 로그인 하지 않은 상태로 초대를 받을 때, 로그인페이지로 인터셉트 당하여 아래 페이지가 나오지 않는 이슈가 있었습니다.
<img width="558" alt="image" src="https://github.com/user-attachments/assets/0f540a6a-1931-44a2-911e-e33674c22309" />

- 이는 `middleware.ts`에서 토큰여부확인하는 로직을 수정했습니다. 
- 원래는 `accessToken`만 없으면 바로 로그인페이지로 이동하게 되어있었는데, 
- 초대를 받으면 로컬스토리지에 INVITATION_ID를 저장하고 그것을 이용해 로컬스토리지에 초대 아이디가 있는지 까지 확인 한 후에 토큰과 초대아이디 모두 없을때 로그인페이지로 이동합니다.
```
if (!accessToken && !localStorage.getItem(STORAGE_KEY.INVITATION_ID)) {
      window.location.replace(PATH.LOGIN);
      throw new Error('토큰이 존재하지 않습니다.');
    }
```
- (로컬스토리지의 초대아이디는 초대와 관련된 로직이 끝나면 삭제됩니다)

---

## 📌스크린샷 (선택)
