### PR TITLE
[Fix]대시보드페이지의 파일섹션 QA

### DIFF
--- a/apps/client/src/page/dashboard/component/File/FileSection.tsx
+++ b/apps/client/src/page/dashboard/component/File/FileSection.tsx
@@ -33,11 +33,7 @@ const FileSection = () => {
   const allFileData = [...docDataList, ...folderDataList];
 
   return (
-    <Flex
-      css={containerStyle}
-      onClick={() => {
-        navigate(PATH.DRIVE);
-      }}>
+    <Flex css={containerStyle}>
       {!allFileData[0] && <ItemAdder path={PATH.DRIVE} />}
       {allFileData.map((item) => {
         if (hasKeyInObject(item, 'documentId')) {
@@ -49,6 +45,9 @@ const FileSection = () => {
               variant="secondary"
               {...file}
               type={extractFileExtension(file.name) as File}
+              onClick={() => {
+                navigate(PATH.DRIVE);
+              }}
             />
           );
         } else if (hasKeyInObject(item, 'folderId')) {
@@ -61,6 +60,9 @@ const FileSection = () => {
               name={folder.name}
               createdTime={folder.createdTime}
               path={folder.path}
+              onClick={() => {
+                navigate(PATH.DRIVE);
+              }}
             />
           );
         }

--- a/apps/client/src/shared/component/FileGrid/FileGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FileGrid.tsx
@@ -63,7 +63,7 @@ const FileGrid = ({
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      <button css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
+      <button type="button" css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
         {isSelectable && (
           <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
         )}

--- a/apps/client/src/shared/component/FileGrid/FileGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FileGrid.tsx
@@ -28,6 +28,7 @@ export type FileGridProps = components['schemas']['DocumentGetResponse'] & {
   onSelect?: () => void;
   onDelete?: () => void;
   isDeleted?: boolean;
+  onClick?: () => void;
 
   /**
    * [TODO]
@@ -46,6 +47,7 @@ const FileGrid = ({
   isSelected = false,
   isDeleted = false,
   onDelete = () => {},
+  onClick = () => {},
 }: FileGridProps) => {
   const { isOpen, close, toggle } = useOverlay();
 
@@ -61,59 +63,61 @@ const FileGrid = ({
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      {isSelectable && (
-        <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
-      )}
-      <div css={iconWrapperStyle(variant !== 'primary')}>{getIconByType(type)}</div>
-      <Flex
-        styles={{
-          direction: 'column',
-          gap: variant === 'primary' ? '1.2rem' : '0.8rem',
-        }}>
-        <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
-          <Heading css={nameStyle} tag="H3">
-            {name}
-          </Heading>
-          {variant === 'primary' && (
-            <MenuRoot onClose={close}>
-              <div ref={optionRef}>
-                {!isDeleted && <IcThreeDots onClick={toggle} css={{ cursor: 'pointer' }} width={16} height={16} />}
-              </div>
+      <button onClick={onClick}>
+        {isSelectable && (
+          <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
+        )}
+        <div css={iconWrapperStyle(variant !== 'primary')}>{getIconByType(type)}</div>
+        <Flex
+          styles={{
+            direction: 'column',
+            gap: variant === 'primary' ? '1.2rem' : '0.8rem',
+          }}>
+          <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
+            <Heading css={nameStyle} tag="H3">
+              {name}
+            </Heading>
+            {variant === 'primary' && (
+              <MenuRoot onClose={close}>
+                <div ref={optionRef}>
+                  {!isDeleted && <IcThreeDots onClick={toggle} css={{ cursor: 'pointer' }} width={16} height={16} />}
+                </div>
 
-              <MenuList css={optionListStyle(getRenderedSection())} isOpen={isOpen}>
-                <MenuItem
-                  css={optionTextStyle}
-                  LeftIcon={OPTION_ICON.download}
-                  onSelect={() => {
-                    downloadDocument(url, name);
-                  }}>
-                  파일 다운로드
-                </MenuItem>
-                <MenuItem css={optionTextStyle} LeftIcon={OPTION_ICON.deleted} onSelect={onDelete}>
-                  휴지통으로 이동
-                </MenuItem>
-                <MenuItem
-                  css={optionTextStyle}
-                  LeftIcon={OPTION_ICON.handover}
-                  onSelect={() => {
-                    alert('준비 중인 기능입니다.');
-                  }}>
-                  인수인계 노트 보기
-                </MenuItem>
-              </MenuList>
-            </MenuRoot>
-          )}
-        </Flex>
+                <MenuList css={optionListStyle(getRenderedSection())} isOpen={isOpen}>
+                  <MenuItem
+                    css={optionTextStyle}
+                    LeftIcon={OPTION_ICON.download}
+                    onSelect={() => {
+                      downloadDocument(url, name);
+                    }}>
+                    파일 다운로드
+                  </MenuItem>
+                  <MenuItem css={optionTextStyle} LeftIcon={OPTION_ICON.deleted} onSelect={onDelete}>
+                    휴지통으로 이동
+                  </MenuItem>
+                  <MenuItem
+                    css={optionTextStyle}
+                    LeftIcon={OPTION_ICON.handover}
+                    onSelect={() => {
+                      alert('준비 중인 기능입니다.');
+                    }}>
+                    인수인계 노트 보기
+                  </MenuItem>
+                </MenuList>
+              </MenuRoot>
+            )}
+          </Flex>
 
-        <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
-          <Text tag="body8" css={textStyle}>
-            {type.toUpperCase()} 문서
-          </Text>
-          <Text tag="body8" css={textStyle}>
-            {getFileVolume(capacity ?? 0)}
-          </Text>
+          <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
+            <Text tag="body8" css={textStyle}>
+              {type.toUpperCase()} 문서
+            </Text>
+            <Text tag="body8" css={textStyle}>
+              {getFileVolume(capacity ?? 0)}
+            </Text>
+          </Flex>
         </Flex>
-      </Flex>
+      </button>
     </article>
   );
 };

--- a/apps/client/src/shared/component/FileGrid/FileGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FileGrid.tsx
@@ -63,7 +63,7 @@ const FileGrid = ({
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      <button onClick={onClick}>
+      <button css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
         {isSelectable && (
           <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
         )}

--- a/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
@@ -36,7 +36,7 @@ const FolderGrid = ({
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      <button onClick={onClick}>
+      <button css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
         {isSelectable && (
           <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
         )}

--- a/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
@@ -14,6 +14,8 @@ type FolderGridProps = {
   onSelect?: () => void;
   isSelected?: boolean;
   onDelete?: () => void;
+  onClick?: () => void;
+
   /**
    * TODO
    * onChangeName
@@ -28,46 +30,49 @@ const FolderGrid = ({
   isSelected = false,
   onSelect = () => {},
   onDelete = () => {},
+  onClick = () => {},
 }: FolderGridProps) => {
   const { isOpen, close, toggle } = useOverlay();
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      {isSelectable && (
-        <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
-      )}
-      <div css={iconWrapperStyle(variant !== 'primary')}>{<IcFolderLarge width={40} height={40} />}</div>
-
-      <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
-        <Heading css={nameStyle} tag="H3">
-          {name}
-        </Heading>
-
-        {variant === 'primary' && (
-          <MenuRoot onClose={close}>
-            <IcThreeDots onClick={toggle} css={{ cursor: 'pointer' }} width={16} height={16} />
-            <MenuList
-              css={{ top: 'calc(100% + 0.4rem)', right: 0, backgroundColor: theme.colors.white }}
-              isOpen={isOpen}>
-              <MenuItem
-                css={optionTextStyle}
-                LeftIcon={OPTION_ICON.name}
-                onSelect={() => alert('준비 중인 기능입니다.')}>
-                이름 변경
-              </MenuItem>
-              <MenuItem
-                css={optionTextStyle}
-                LeftIcon={OPTION_ICON.download}
-                onSelect={() => alert('준비 중인 기능입니다.')}>
-                폴더 전체 다운로드
-              </MenuItem>
-              <MenuItem css={optionTextStyle} LeftIcon={OPTION_ICON.deleted} onSelect={onDelete}>
-                휴지통으로 이동
-              </MenuItem>
-            </MenuList>
-          </MenuRoot>
+      <button onClick={onClick}>
+        {isSelectable && (
+          <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
         )}
-      </Flex>
+        <div css={iconWrapperStyle(variant !== 'primary')}>{<IcFolderLarge width={40} height={40} />}</div>
+
+        <Flex styles={{ width: '100%', justify: 'space-between', align: 'center' }}>
+          <Heading css={nameStyle} tag="H3">
+            {name}
+          </Heading>
+
+          {variant === 'primary' && (
+            <MenuRoot onClose={close}>
+              <IcThreeDots onClick={toggle} css={{ cursor: 'pointer' }} width={16} height={16} />
+              <MenuList
+                css={{ top: 'calc(100% + 0.4rem)', right: 0, backgroundColor: theme.colors.white }}
+                isOpen={isOpen}>
+                <MenuItem
+                  css={optionTextStyle}
+                  LeftIcon={OPTION_ICON.name}
+                  onSelect={() => alert('준비 중인 기능입니다.')}>
+                  이름 변경
+                </MenuItem>
+                <MenuItem
+                  css={optionTextStyle}
+                  LeftIcon={OPTION_ICON.download}
+                  onSelect={() => alert('준비 중인 기능입니다.')}>
+                  폴더 전체 다운로드
+                </MenuItem>
+                <MenuItem css={optionTextStyle} LeftIcon={OPTION_ICON.deleted} onSelect={onDelete}>
+                  휴지통으로 이동
+                </MenuItem>
+              </MenuList>
+            </MenuRoot>
+          )}
+        </Flex>
+      </button>
     </article>
   );
 };

--- a/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
+++ b/apps/client/src/shared/component/FileGrid/FolderGrid.tsx
@@ -1,9 +1,15 @@
 import { IcFolderLarge, IcThreeDots } from '@tiki/icon';
-import { CheckBox, Flex, Heading, MenuItem, MenuList, MenuRoot, theme } from '@tiki/ui';
+import { CheckBox, Flex, Heading, MenuItem, MenuList, MenuRoot } from '@tiki/ui';
 import { useOverlay } from '@tiki/utils';
 
 import { OPTION_ICON } from '@/shared/component/FileGrid/icon';
-import { cardStyle, iconWrapperStyle, nameStyle, optionTextStyle } from '@/shared/component/FileGrid/index.style';
+import {
+  cardStyle,
+  folderMenuListStyle,
+  iconWrapperStyle,
+  nameStyle,
+  optionTextStyle,
+} from '@/shared/component/FileGrid/index.style';
 
 type FolderGridProps = {
   variant?: 'primary' | 'secondary';
@@ -36,7 +42,7 @@ const FolderGrid = ({
 
   return (
     <article css={cardStyle(variant !== 'primary')}>
-      <button css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
+      <button type="button" css={{ width: '100%', backgroundColor: 'transparent' }} onClick={onClick}>
         {isSelectable && (
           <CheckBox css={{ position: 'absolute', right: 20 }} isChecked={isSelected} onChange={() => onSelect?.()} />
         )}
@@ -50,9 +56,7 @@ const FolderGrid = ({
           {variant === 'primary' && (
             <MenuRoot onClose={close}>
               <IcThreeDots onClick={toggle} css={{ cursor: 'pointer' }} width={16} height={16} />
-              <MenuList
-                css={{ top: 'calc(100% + 0.4rem)', right: 0, backgroundColor: theme.colors.white }}
-                isOpen={isOpen}>
+              <MenuList css={folderMenuListStyle} isOpen={isOpen}>
                 <MenuItem
                   css={optionTextStyle}
                   LeftIcon={OPTION_ICON.name}

--- a/apps/client/src/shared/component/FileGrid/index.style.ts
+++ b/apps/client/src/shared/component/FileGrid/index.style.ts
@@ -84,3 +84,10 @@ export const optionTextStyle = css({
 
   fontWeight: 400,
 });
+
+export const folderMenuListStyle = css({
+  top: 'calc(100% + 0.4rem)',
+  right: 0,
+
+  backgroundColor: theme.colors.white,
+});

--- a/apps/client/src/shared/component/FileGrid/index.style.ts
+++ b/apps/client/src/shared/component/FileGrid/index.style.ts
@@ -22,6 +22,8 @@ export const cardStyle = (isSmall: boolean) =>
 
 export const iconWrapperStyle = (isSmall: boolean) =>
   css({
+    display: 'flex',
+
     width: '100%',
 
     padding: isSmall ? '0 0 1.8rem' : '1.2rem 0 2rem 0',


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #501 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- 대시보드 페이지의 파일섹션에서 + 버튼을 눌러 파일을 추가하려했을때, `navigate(PATH.DRIVE)`함수가 두번 실행되어 뒤로가기를 두번눌러야 대시보드페이지로 이동되는 이슈가 있었습니다.
- 파일섹션 전체에 걸어둔 네비게이트를 제거하고 파일/폴더 그리드 각각에 버튼 태그를 추가하고 onClick이벤트를 주입함으로써 이슈를 해결할 수 있었습니다. 
- 버튼 태그를 추가하니 이미지가 가운데로 배치되는 이슈가 있어 이미지 스타일에 `display:'flex'`를 넣어 왼쪽으로 이동시킬 수 있었습니다.
---
